### PR TITLE
Does not set alarms infinitely and cleans up alarms on destroy

### DIFF
--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -844,7 +844,6 @@ export class Container<Env = unknown> extends DurableObject<Env> {
    */
   async stop(signal = 15): Promise<void> {
     this.container.signal(signal);
-    await this.ctx.storage.deleteAlarm();
   }
 
   /**
@@ -852,7 +851,6 @@ export class Container<Env = unknown> extends DurableObject<Env> {
    */
   async destroy(): Promise<void> {
     await this.container.destroy();
-    await this.ctx.storage.deleteAlarm();
   }
 
   /**
@@ -1225,7 +1223,7 @@ export class Container<Env = unknown> extends DurableObject<Env> {
 
       // Only schedule next alarm if there are pending schedules or container is running
       const hasScheduledTasks = this.sql`SELECT COUNT(*) as count FROM container_schedules`[0]?.count > 0;
-      if (hasScheduledTasks || this.container.running) {
+      if (hasScheduledTasks) {
         await this.#scheduleNextAlarm();
       }
 


### PR DESCRIPTION
Fixes alarm issues that would keep Durable Object alive indefinitely:

- schedules next alarm if there are pending tasks or container is running
- added check to prevent unnecessary rescheduling on retries