### PR TITLE
Setting up retries to throw errors in lieu of working abort signal

### DIFF
--- a/example/wrangler.jsonc
+++ b/example/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "container-example-class-fooey",
+	"name": "container-package-class-worker",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-05-06",
 	"compatibility_flags": [
@@ -13,8 +13,8 @@
     {
       "class_name": "MyContainer",
       "image": "./Dockerfile",
-      "max_instances": 10,
-      "name": "container-package-class-fooey"
+      "max_instances": 3,
+      "name": "container-package-class-example"
     }
   ],
   "durable_objects": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/containers",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/containers",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "license": "ISC",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250403.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/containers",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/containers",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "ISC",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250403.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@cloudflare/containers",
-  "version": "0.0.4",
-  "description": "TypeScript helper class for PartyKit durable object containers",
+  "version": "0.0.5",
+  "description": "Helper class for container-enabled Durable Objects",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "repository": "cloudflare/containers",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/containers",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "TypeScript helper class for PartyKit durable object containers",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1037,8 +1037,8 @@ export class Container<Env = unknown> extends DurableObject<Env> {
   override async alarm(alarmProps: { isRetry: boolean; retryCount: number }): Promise<void> {
     if (alarmProps.isRetry && alarmProps.retryCount > MAX_ALAEM_RETRIES) {
       // Only reschedule if there are pending tasks or container is running
-      const hasScheduledTasks =
-        this.sql`SELECT COUNT(*) as count FROM container_schedules`[0]?.count > 0;
+      const scheduleCount = Number(this.sql`SELECT COUNT(*) as count FROM container_schedules`[0]?.count) || 0;
+      const hasScheduledTasks = scheduleCount > 0;
       if (hasScheduledTasks || this.container.running) {
         await this.scheduleNextAlarm();
       }
@@ -1100,8 +1100,8 @@ export class Container<Env = unknown> extends DurableObject<Env> {
       }
 
       // Only schedule next alarm if there are pending schedules or container is running
-      const hasScheduledTasks =
-        this.sql`SELECT COUNT(*) as count FROM container_schedules`[0]?.count > 0;
+      const scheduleCount = Number(this.sql`SELECT COUNT(*) as count FROM container_schedules`[0]?.count) || 0;
+      const hasScheduledTasks = scheduleCount > 0;
       if (hasScheduledTasks) {
         await this.scheduleNextAlarm();
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,12 +41,6 @@ export interface ContainerOptions {
 
   /** Whether to enable internet access for the container */
   enableInternet?: boolean;
-
-  /** If true, container won't be started automatically when the durable object starts */
-  explicitContainerStart?: boolean;
-
-  /** If true, container won't be started automatically when the durable object starts (preferred over explicitContainerStart) */
-  manualStart?: boolean;
 }
 
 
@@ -71,6 +65,7 @@ export interface WaitOptions {
   abort?: AbortSignal;
   retries: number;
   waitInterval: number;
+  portToCheck: number;
 }
 
 /**


### PR DESCRIPTION
- Surfaces error better
- Does not autostart a container in constructor, so we can throw error nicely
