### PR TITLE
fix sleepAfter by making the alarm run immediately after finishing running alarm()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/containers",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Helper class for container-enabled Durable Objects",
   "repository": {
     "type": "git",

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1137,8 +1137,6 @@ export class Container<Env = unknown> extends DurableObject<Env> {
     maxTime = maxTime === 0 ? Date.now() + 60 * 3 * 1000 : maxTime;
     maxTime = Math.min(maxTime, this.sleepAfterMs);
     const timeout = Math.max(0, maxTime - Date.now());
-    await this.ctx.storage.setAlarm(timeout + Date.now());
-    await this.ctx.storage.sync();
 
     // await a sleep for maxTime to keep the DO alive for
     // at least this long


### PR DESCRIPTION
    The reason this is necessary is that if the DO gets reset, we still need
    to bring up the DO. What we are doing here is not resetting hte alarm
    that is set at the beginning of the function.