### PR TITLE
add switchPort and examples on how to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The main class that extends a container-enbled Durable Object to provide additio
 
 #### Properties
 
-- `defaultPort?`: Optional default port to use when communicating with the container. If not set, you must specify port in containerFetch calls
+- `defaultPort?`: Optional default port to use when communicating with the container. If not set, you must specify port in `containerFetch` calls, or use `switchPort`.
 - `requiredPorts?`: Array of ports that should be checked for availability during container startup. Used by startAndWaitForPorts when no specific ports are provided.
 - `sleepAfter`: How long to keep the container alive without activity (format: number for seconds, or string like "5m", "30s", "1h")
 - `env`: Environment variables to pass to the container (Record<string, string>)
@@ -101,6 +101,10 @@ If you don't stop the container here, the activity tracker will be renewed, and 
   - `containerFetch(url, init?, port?)`: Standard fetch-like signature with URL string/object and RequestInit options
   Either port parameter or defaultPort must be specified.
   When you call any of the fetch functions, the activity will be automatically renewed, and if the container will be started if not already running.
+  **Do not use 'containerFetch' when trying to send a Request object with a websocket, until [this issue is addressed](https://github.com/cloudflare/workerd/issues/2319).
+  You can overcome this limitation by doing:
+  `container.fetch(switchPort(request, port))`
+
 - `start()`: Starts the container if it's not running and sets up monitoring, without waiting for any ports to be ready.
 - `startAndWaitForPorts(ports?, maxTries?)`: Starts the container using `start()` and then waits for specified ports to be ready. If no ports are specified, uses `requiredPorts` or `defaultPort`. If no ports can be determined, just starts the container without port checks.
 - `stop(signal = SIGTERM)`: Sends the specified signal to the container.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { Container } from './lib/container';
-export { getRandom, loadBalance, getContainer } from './lib/utils';
+export { getRandom, loadBalance, getContainer, switchPort } from './lib/utils';
 export type {
   ContainerOptions,
   ContainerEventHandler,

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -735,15 +735,14 @@ export class Container<Env = unknown> extends DurableObject<Env> {
    * @param request The request to handle
    */
   override async fetch(request: Request): Promise<Response> {
-    if (this.defaultPort === undefined) {
-      return new Response(
-        'No default port configured for this container. Override the fetch method or set defaultPort in your Container subclass.',
-        { status: 500 }
+    const url = new URL(request.url);
+    if (this.defaultPort === undefined && url.port === '') {
+      throw new Error(
+        'No port configured for this container. Set the defaultPort in your Container subclass, or set a port with switchPort.'
       );
     }
 
-    const url = new URL(request.url);
-    const portValue = url.port === '' ? this.defaultPort : +url.port;
+    const portValue = +(url.port === '' ? (this.defaultPort ?? '') : url.port);
     if (isNaN(portValue)) {
       throw new Error('port is not a number');
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,7 +33,7 @@ export async function loadBalance<T extends Container>(
 ): Promise<DurableObjectStub<T>> {
   console.warn(
     'loadBalance is deprecated, please use getRandom instead. This will be removed in a future version.'
-  )
+  );
   return getRandom(binding, instances);
 }
 
@@ -50,4 +50,17 @@ export function getContainer<T extends Container>(
 ): DurableObjectStub<T> {
   const objectId = binding.idFromName(name ?? singletonContainerId);
   return binding.get(objectId);
+}
+
+/**
+ * Return a request with the port target set correctly
+ * You can use this method when you have to use `fetch` and not `containerFetch` with as it's a JSRPC method and it
+ * comes with some consequences like not being able to pass WebSockets.
+ *
+ * @example container.fetch(switchPort(request, 8090));
+ */
+export function switchPort(request: Request, port: number): Request {
+  const url = new URL(request.url);
+  url.port = `${port}`;
+  return new Request(url, request);
 }


### PR DESCRIPTION
Due to `containerFetch` usage outside the DO being unable to do WebSockets due to https://github.com/cloudflare/workerd/issues/2319, we are providing a helper to switch the port on a HTTP request.