### PR TITLE
Expose private state through public getState interface

### DIFF
--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -280,6 +280,14 @@ export class Container<Env = unknown> extends DurableObject<Env> {
     }
   }
 
+  /**
+   * Gets the current state of the container
+   * @returns Promise<State>
+   */
+  async getState(): Promise<State> {
+    return { ...this.state.getState() };
+  }
+
   // ==========================
   //     CONTAINER STARTING
   // ==========================


### PR DESCRIPTION
Closes #42

It's useful to know the current state of the container. I was implementing my own state implementation based on lifecycle methods, but then saw there was already a private interface that tracked the current state of the container.

This change exposes a public `getState()` method which returns a copy of the underlying container state