### PR TITLE
Throw earlier if no containers have been configured

### DIFF
--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -238,6 +238,12 @@ export class Container<Env = unknown> extends DurableObject<Env> {
   constructor(ctx: DurableObject['ctx'], env: Env, options?: ContainerOptions) {
     super(ctx, env);
 
+    if (ctx.container === undefined) {
+      throw new Error(
+        'Containers have not been enabled for this Durable Object class. Have you correctly setup your Wrangler config? More info: https://developers.cloudflare.com/containers/get-started/#configuration'
+      );
+    }
+
     this.state = new ContainerState(this.ctx.storage);
 
     this.ctx.blockConcurrencyWhile(async () => {
@@ -246,12 +252,6 @@ export class Container<Env = unknown> extends DurableObject<Env> {
       // First thing, schedule the next alarms
       await this.scheduleNextAlarm();
     });
-
-    if (ctx.container === undefined) {
-      throw new Error(
-        'Container is not enabled for this durable object class. Have you correctly setup your wrangler.toml?'
-      );
-    }
 
     this.container = ctx.container;
 


### PR DESCRIPTION
Trying to get make vitest not broken with containers and ran into an issue because the keep alive alarms were being set even if containers were not configured, and vitest is not good with DO alarms 🫠.