### PR TITLE
fix: call onStart after status is set to healthy

### DIFF
--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -508,8 +508,8 @@ export class Container<Env = unknown> extends DurableObject<Env> {
 
     await this.ctx.blockConcurrencyWhile(async () => {
       // All ports are ready
-      await this.onStart();
       await this.state.setHealthy();
+      await this.onStart();
     });
   }
 


### PR DESCRIPTION
Currently, any attempt to call  `await super.containerFetch(...)` within `onStart() {...}` will recursively start the container.  This happens because the container status is set to healthy _after_ `onStart` is invoked. This can be mitigated via `setTimeout` but that's suboptimal.