### PR TITLE
Alarm props is optional

### DIFF
--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1042,8 +1042,8 @@ export class Container<Env = unknown> extends DurableObject<Env> {
    * Executes any scheduled tasks that are due
    */
 
-  override async alarm(alarmProps: { isRetry: boolean; retryCount: number }): Promise<void> {
-    if (alarmProps.isRetry && alarmProps.retryCount > MAX_ALARM_RETRIES) {
+  override async alarm(alarmProps?: { isRetry: boolean; retryCount: number }): Promise<void> {
+    if (alarmProps?.isRetry && alarmProps?.retryCount > MAX_ALARM_RETRIES) {
       const scheduleCount =
         Number(this.sql`SELECT COUNT(*) as count FROM container_schedules`[0]?.count) || 0;
       const hasScheduledTasks = scheduleCount > 0;


### PR DESCRIPTION
According to docs the alarmprops is optional. Getting this error without, and it doesnt keep the container alive as long as defined in `sleepAfter`.

```
TypeError: Cannot read properties of undefined (reading 'isRetry')
    at MyContainerDO.alarm (index.js:12141:27)
    at index.js:11740:13
```