### PR TITLE
fix not being able to find port in local dev

### DIFF
--- a/.changeset/sour-mangos-relax.md
+++ b/.changeset/sour-mangos-relax.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/containers': patch
+---
+
+fix: use default port by default when making fetch requests to containers. this was breaking local dev as we would check the port of the host url, rather than the port the container was listening on. this was not an issue in production, as all ports are exposed there.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,7 +60,7 @@ export function getContainer<T extends Container>(
  * @example container.fetch(switchPort(request, 8090));
  */
 export function switchPort(request: Request, port: number): Request {
-  const url = new URL(request.url);
-  url.port = `${port}`;
-  return new Request(url, request);
+  const headers = new Headers(request.headers);
+  headers.set('cf-container-target-port', port.toString());
+  return new Request(request, { headers });
 }


### PR DESCRIPTION
default to the default port, unless switchPort is used. switchPort now uses a header so we know the port is coming from that and should override the default.

This fixes the issue where local dev didn't work unless the default container port was the same as the port wrangler/vite was using