### PR TITLE
improve port checking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,13 +21,18 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install dependencies
-        working-directory: fixtures/basic
-        run: npm install
-        
-      - name: Run integration tests
-        working-directory: fixtures/basic
-        run: npm run test
+      - name: Install dependencies and run tests for all fixtures
+        run: |
+          for fixture in fixtures/*/; do
+            if [ -f "$fixture/package.json" ]; then
+              echo "Installing dependencies for $fixture"
+              cd "$fixture"
+              npm install
+              echo "Running tests for $fixture"
+              npm run test
+              cd - > /dev/null
+            fi
+          done
         timeout-minutes: 10
         
         
@@ -47,6 +52,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Type check fixtures
-        working-directory: fixtures/basic
-        run: npx tsc --noEmit
+      - name: Type check all fixtures
+        run: |
+          for fixture in fixtures/*/; do
+            if [ -f "$fixture/tsconfig.json" ]; then
+              echo "Type checking $fixture"
+              cd "$fixture"
+              npx tsc --noEmit
+              cd - > /dev/null
+            fi
+          done

--- a/fixtures/helpers/index.ts
+++ b/fixtures/helpers/index.ts
@@ -32,6 +32,7 @@ export class WranglerDevRunner {
       this.process.stdout.on('data', (data: Buffer) => {
         const output = data.toString();
         this.stdout += output;
+        console.log(output);
 
         // Check for ready pattern
         const match = output.match(/Ready on (?<url>https?:\/\/.*)/);
@@ -44,6 +45,7 @@ export class WranglerDevRunner {
 
       this.process.stderr.on('data', (data: Buffer) => {
         this.stderr += data.toString();
+        console.log(data.toString());
       });
     });
   }
@@ -64,7 +66,8 @@ export class WranglerDevRunner {
     for (const id of containerId) {
       await fetch(this.url + '/stop?id=' + id);
     }
-
+    // give it a second to run the onStop hook before we kill the process
+    await new Promise(resolve => setTimeout(resolve, 1000));
     this.process.kill('SIGTERM');
 
     // Wait a bit for the process to finish

--- a/fixtures/multiple-ports/Dockerfile
+++ b/fixtures/multiple-ports/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+FROM node:22-alpine
+
+WORKDIR /usr/src/app
+
+RUN echo '{"name": "test-container", "version": "1.0.0"}' > package.json
+
+COPY container_src/server.js server.js
+
+EXPOSE 8080 8081
+STOPSIGNAL SIGINT

--- a/fixtures/multiple-ports/container_src/server.js
+++ b/fixtures/multiple-ports/container_src/server.js
@@ -1,0 +1,45 @@
+import { createServer } from "http";
+import { setTimeout } from "timers/promises";
+
+const server = createServer(function (req, res) {
+  if (req.url === '/error') {
+    res.writeHead(500, { "Content-Type": "text/plain" });
+    res.end("Internal server error");
+    return;
+  }
+  
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end(`Hello from test container server one! process.env.MESSAGE: ${process.env.MESSAGE}`);
+});
+
+server.listen(8080, function () {
+  console.log(`Test server listening on port 8080`);
+});
+server.on("exit", () => {
+  console.log("Test server one exiting");
+})
+
+
+
+await setTimeout(5000)
+
+
+const server2 = createServer(function (req, res) {
+  if (req.url === '/error') {
+    res.writeHead(500, { "Content-Type": "text/plain" });
+    res.end("Internal server error");
+    return;
+  }
+  
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end(`Hello from test container server two! process.env.MESSAGE: ${process.env.MESSAGE}`);
+});
+server2.listen(8081, function () {
+  console.log(`Test server two listening on port 8081`);
+}); 
+
+server2.on("exit", function () {
+  console.log("Test server two exiting");
+}); 
+
+

--- a/fixtures/multiple-ports/package.json
+++ b/fixtures/multiple-ports/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "containers-test-fixture",
+  "version": "1.0.0",
+  "description": "Integration test fixture for @cloudflare/containers",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:local": "vitest run -t 'Local Instance Tests'",
+    "test:deployed": "vitest run -t 'Deployed Instance Tests'",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0",
+    "wrangler": "https://pkg.pr.new/wrangler@main"
+  },
+  "dependencies": {
+    "@cloudflare/workers-types": "^4.0.0"
+  }
+}

--- a/fixtures/multiple-ports/src/index.ts
+++ b/fixtures/multiple-ports/src/index.ts
@@ -1,0 +1,91 @@
+import { Container } from '../../../src/lib/container';
+import { getContainer, getRandom, switchPort } from '../../../src/lib/utils';
+
+/**
+ * Test Container implementation for integration testing
+ */
+export class TestContainer extends Container {
+  defaultPort = 8080;
+
+  // Set how long the container should stay active without requests
+  sleepAfter = '3m';
+
+  constructor(ctx: any, env: any) {
+    super(ctx, env);
+
+    // Set container configuration
+    this.envVars = {
+      MESSAGE: 'default message',
+    };
+    this.entrypoint = ['node', 'server.js'];
+  }
+
+  override async onStart(): Promise<void> {
+    console.log('onStart hook called');
+  }
+
+  override async onStop(): Promise<void> {
+    console.log('onStop hook called');
+  }
+
+  override onError(error: unknown): any {
+    console.log('onError hook called with error:', error);
+    throw error;
+  }
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: { CONTAINER: DurableObjectNamespace<TestContainer> }
+  ): Promise<Response> {
+    const url = new URL(request.url);
+    // get a new container instance per request
+
+    const id = url.searchParams.get('id') || 'singleton';
+    const container = getContainer(env.CONTAINER, id);
+
+    if (url.pathname === '/startAndWaitFor8080') {
+      // waits for default port 8080 only
+      await container.startAndWaitForPorts({
+        startOptions: {
+          envVars: { MESSAGE: 'start with startAndWaitForPorts' },
+        },
+      });
+      return new Response('start request sent waiting for 8080');
+    }
+    if (url.pathname === '/startAndWaitForAllPorts') {
+      // waits for default port 8080 only
+      await container.startAndWaitForPorts({
+        startOptions: {
+          envVars: { MESSAGE: 'start with startAndWaitForPorts' },
+        },
+        ports: [8080, 8081],
+      });
+      return new Response('start request sent waiting for all ports');
+    }
+    if (url.pathname === '/server-one') {
+      return container.containerFetch(request, 8080);
+    }
+    if (url.pathname === '/server-two') {
+      return container.containerFetch(request, 8081);
+    }
+    if (url.pathname === '/start') {
+      await container.start({
+        envVars: { MESSAGE: 'start with start' },
+      });
+      return new Response('start request sent');
+    }
+    if (url.pathname === '/waitForPort') {
+      const portToCheck = parseInt(url.searchParams.get('port') || '8080');
+      await container.waitForPort({ portToCheck });
+      return new Response('port');
+    }
+
+    if (url.pathname === '/stop') {
+      await container.destroy();
+      return new Response('Container stopping');
+    }
+    return new Response('Not Found');
+  },
+};

--- a/fixtures/multiple-ports/test/index.test.ts
+++ b/fixtures/multiple-ports/test/index.test.ts
@@ -1,0 +1,70 @@
+import { WranglerDevRunner } from '../../helpers/index.js';
+import { test, expect, describe } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+const fetchOrTimeout = async (fetchPromise: Promise<Response>, timeoutMs: number) => {
+  const timeoutPromise = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('timeout')), timeoutMs)
+  );
+  return await Promise.race([fetchPromise, timeoutPromise]);
+};
+
+describe('multiple ports functionality', () => {
+  test('waitForPort should wait for port to be ready before returning', async () => {
+    const runner = new WranglerDevRunner();
+    const url = await runner.getUrl();
+    const id = randomUUID();
+
+    // This only waits for the default port 8080 to be ready
+    await fetch(`${url}/startAndWaitFor8080?id=${id}`);
+
+    // first server should be ready immediately
+    let fetchPromise = fetch(`${url}/server-one?id=${id}`);
+    let res = (await fetchOrTimeout(fetchPromise, 1000)) as Response;
+    expect(await res.text()).toBe(
+      'Hello from test container server one! process.env.MESSAGE: start with startAndWaitForPorts'
+    );
+
+    // Second server listening on 8081 should not be ready yet - this call should not resolve within 1s
+    fetchPromise = fetch(`${url}/server-two?id=${id}`);
+    expect(fetchOrTimeout(fetchPromise, 1000)).rejects.toThrow('timeout');
+
+    // Wait for the default port (8080) to be ready
+
+    await fetch(`${url}/waitForPort?id=${id}&port=8081`);
+
+    // Verify the container is actually ready by making a request
+    fetchPromise = fetch(`${url}/server-two?id=${id}`);
+    res = (await fetchOrTimeout(fetchPromise, 1000)) as Response;
+    expect(await res.text()).toBe(
+      'Hello from test container server two! process.env.MESSAGE: start with startAndWaitForPorts'
+    );
+
+    await runner.stop([id]);
+  });
+
+  test('startAndWaitForPorts should wait for all specified ports to be ready', async () => {
+    const runner = new WranglerDevRunner();
+    const url = await runner.getUrl();
+    const id = randomUUID();
+
+    // Start and wait for ports should wait for all ports to be ready
+    await fetch(`${url}/startAndWaitForAllPorts?id=${id}`);
+
+    // first server should be ready immediately
+    let fetchPromise = fetch(`${url}/server-one?id=${id}`);
+    let res = (await fetchOrTimeout(fetchPromise, 1000)) as Response;
+    expect(await res.text()).toBe(
+      'Hello from test container server one! process.env.MESSAGE: start with startAndWaitForPorts'
+    );
+
+    // second server should be ready immediately
+    fetchPromise = fetch(`${url}/server-two?id=${id}`);
+    res = (await fetchOrTimeout(fetchPromise, 1000)) as Response;
+    expect(await res.text()).toBe(
+      'Hello from test container server two! process.env.MESSAGE: start with startAndWaitForPorts'
+    );
+
+    await runner.stop([id]);
+  });
+});

--- a/fixtures/multiple-ports/tsconfig.json
+++ b/fixtures/multiple-ports/tsconfig.json
@@ -1,0 +1,44 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2021",
+    /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["es2021"],
+    /* Specify what JSX code is generated. */
+    "jsx": "react-jsx",
+
+    /* Specify what module code is generated. */
+    "module": "es2022",
+    /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "Bundler",
+    /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["@cloudflare/workers-types/2023-07-01"],
+    /* Enable importing .json files */
+    "resolveJsonModule": true,
+
+    /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    "allowJs": true,
+    /* Enable error reporting in type-checked JavaScript files. */
+    "checkJs": false,
+
+    /* Disable emitting files from a compilation. */
+    "noEmit": true,
+
+    /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "isolatedModules": true,
+    /* Allow 'import x from y' when a module doesn't have a default export. */
+    "allowSyntheticDefaultImports": true,
+    /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true,
+
+    /* Enable all strict type-checking options. */
+    "strict": true,
+
+    /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true
+  },
+  "exclude": ["test"],
+  "include": ["worker-configuration.d.ts", "src/**/*.ts"]
+}

--- a/fixtures/multiple-ports/vitest.config.ts
+++ b/fixtures/multiple-ports/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 60000,
+    hookTimeout: 120000,
+  },
+});

--- a/fixtures/multiple-ports/wrangler.jsonc
+++ b/fixtures/multiple-ports/wrangler.jsonc
@@ -1,0 +1,30 @@
+{
+  "name": "containers-test-fixture",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-04-03",
+  "observability": {
+    "enabled": true,
+  },
+  "containers": [
+    {
+      "image": "./Dockerfile",
+      "class_name": "TestContainer",
+      "name": "test-container",
+      "max_instances": 2,
+    },
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "class_name": "TestContainer",
+        "name": "CONTAINER",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["TestContainer"],
+    },
+  ],
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -38,26 +38,16 @@ const INSTANCE_POLL_INTERVAL_MS = 300; // Default interval for polling container
 // Timeout for getting container instance and launching a VM
 // Time to find an instance, attach a DO, call start, but NOT
 // the time for the app the actually start
-const TIMEOUT_TO_GET_CONTAINER_SECONDS = 8;
+const TIMEOUT_TO_GET_CONTAINER_MS = 8_000;
 
 // Timeout for getting a container instance and launching
 // the actual application and have it listen for specific ports
 // One day might be configurable by the end user in Container class attribute
-const TIMEOUT_TO_GET_PORTS = 20;
-
-// Number of tries based on polling interval
-const TRIES_TO_GET_CONTAINER = Math.ceil(
-  (TIMEOUT_TO_GET_CONTAINER_SECONDS * 1000) / INSTANCE_POLL_INTERVAL_MS
-);
-const TRIES_TO_GET_PORTS = Math.ceil((TIMEOUT_TO_GET_PORTS * 1000) / INSTANCE_POLL_INTERVAL_MS);
+const TIMEOUT_TO_GET_PORTS_MS = 20_000;
 
 // If user has specified no ports and we need to check one
 // to see if the container is up at all.
 const FALLBACK_PORT_TO_CHECK = 33;
-
-// Since the timing isn't working, hard coding a max attempts seems
-// to be the only viable solution for now
-const TEMPORARY_HARDCODED_ATTEMPT_MAX = 6;
 
 export type Signal = 'SIGKILL' | 'SIGINT' | 'SIGTERM';
 export type SignalInteger = number;
@@ -338,19 +328,22 @@ export class Container<Env = unknown> extends DurableObject<Env> {
    * @throws Error if no container context is available or if all start attempts fail
    */
   public async start(
-    options?: ContainerStartConfigOptions,
-    waitOptions?: { signal?: AbortSignal }
+    startOptions?: ContainerStartConfigOptions,
+    waitOptions?: WaitOptions
   ): Promise<void> {
     const portToCheck =
-      this.defaultPort ?? (this.requiredPorts ? this.requiredPorts[0] : FALLBACK_PORT_TO_CHECK);
+      waitOptions?.portToCheck ??
+      this.defaultPort ??
+      (this.requiredPorts ? this.requiredPorts[0] : FALLBACK_PORT_TO_CHECK);
+    const pollInterval = waitOptions?.waitInterval ?? INSTANCE_POLL_INTERVAL_MS;
     await this.startContainerIfNotRunning(
       {
-        abort: waitOptions?.signal,
-        waitInterval: INSTANCE_POLL_INTERVAL_MS,
-        retries: TRIES_TO_GET_CONTAINER,
+        signal: waitOptions?.signal,
+        waitInterval: pollInterval,
+        retries: waitOptions?.retries ?? Math.ceil(TIMEOUT_TO_GET_CONTAINER_MS / pollInterval),
         portToCheck,
       },
-      options
+      startOptions
     );
 
     this.setupMonitorCallbacks();
@@ -421,86 +414,35 @@ export class Container<Env = unknown> extends DurableObject<Env> {
 
     // Prepare to start the container
     resolvedCancellationOptions ??= {};
-    let containerGetRetries = resolvedCancellationOptions.instanceGetTimeoutMS
-      ? Math.ceil(resolvedCancellationOptions.instanceGetTimeoutMS / INSTANCE_POLL_INTERVAL_MS)
-      : TRIES_TO_GET_CONTAINER;
+    const containerGetTimeout =
+      resolvedCancellationOptions.instanceGetTimeoutMS ?? TIMEOUT_TO_GET_CONTAINER_MS;
+    const pollInterval = resolvedCancellationOptions.waitInterval ?? INSTANCE_POLL_INTERVAL_MS;
+    let containerGetRetries = Math.ceil(containerGetTimeout / pollInterval);
 
-    const waitOptions = {
-      abort: resolvedCancellationOptions.abort,
+    const waitOptions: WaitOptions = {
+      signal: resolvedCancellationOptions.abort,
       retries: containerGetRetries,
-      waitInterval: resolvedCancellationOptions.waitInterval ?? INSTANCE_POLL_INTERVAL_MS,
+      waitInterval: pollInterval,
       portToCheck: portsToCheck[0],
     };
-
-    const abortedSignal = new Promise(res => {
-      waitOptions.abort?.addEventListener('abort', () => {
-        res(true);
-      });
-    });
 
     // Start the container if it's not running
     const triesUsed = await this.startContainerIfNotRunning(waitOptions, resolvedStartOptions);
 
     // Check each port
-    let totalPortReadyTries = resolvedCancellationOptions.portReadyTimeoutMS
-      ? Math.ceil(resolvedCancellationOptions.portReadyTimeoutMS / INSTANCE_POLL_INTERVAL_MS)
-      : TRIES_TO_GET_PORTS;
-    const triesLeft = totalPortReadyTries - triesUsed;
+
+    const totalPortReadyTries = Math.ceil(
+      resolvedCancellationOptions.portReadyTimeoutMS ?? TIMEOUT_TO_GET_PORTS_MS / pollInterval
+    );
+    let triesLeft = totalPortReadyTries - triesUsed;
 
     for (const port of portsToCheck) {
-      const tcpPort = this.container.getTcpPort(port);
-      let portReady = false;
-
-      // Try to connect to the port multiple times
-      for (let i = 0; i < triesLeft && !portReady; i++) {
-        try {
-          const combinedSignal = addTimeoutSignal(waitOptions.abort, PING_TIMEOUT_MS);
-          await tcpPort.fetch('http://ping', { signal: combinedSignal });
-
-          // Successfully connected to this port
-          portReady = true;
-          console.log(`Port ${port} is ready`);
-        } catch (e) {
-          // Check for specific error messages that indicate we should keep retrying
-          const errorMessage = e instanceof Error ? e.message : String(e);
-
-          console.debug(`Error checking ${port}: ${errorMessage}`);
-
-          // If not running, it means the container crashed
-          if (!this.container.running) {
-            try {
-              await this.onError(
-                new Error(
-                  `Container crashed while checking for ports, did you setup the entrypoint correctly?`
-                )
-              );
-            } catch {}
-
-            throw e;
-          }
-
-          // If we're on the last attempt and the port is still not ready, fail
-          if (i === triesLeft - 1) {
-            try {
-              // TODO: Remove attempts, the end user doesn't care about this
-              await this.onError(
-                `Failed to verify port ${port} is available after ${waitOptions.retries} attempts, last error: ${errorMessage}`
-              );
-            } catch {}
-            throw e;
-          }
-
-          // Wait a bit before trying again
-          await Promise.any([
-            new Promise(resolve => setTimeout(resolve, waitOptions.waitInterval)),
-            abortedSignal,
-          ]);
-
-          if (waitOptions.abort?.aborted) {
-            throw new Error('Container request timed out.');
-          }
-        }
-      }
+      triesLeft = await this.waitForPort({
+        signal: resolvedCancellationOptions.abort,
+        waitInterval: pollInterval,
+        retries: triesLeft,
+        portToCheck: port,
+      });
     }
 
     this.setupMonitorCallbacks();
@@ -512,6 +454,79 @@ export class Container<Env = unknown> extends DurableObject<Env> {
     });
   }
 
+  /**
+   *
+   * Waits for a specified port to be ready
+   *
+   * Returns the number of tries used to get the port, or throws if it couldn't get the port within the specified retry limits.
+   *
+   * @param waitOptions -
+   * - `portToCheck`: The port number to check
+   * - `abort`: Optional AbortSignal to cancel waiting
+   * - `retries`: Number of retries before giving up (default: TRIES_TO_GET_PORTS)
+   * - `waitInterval`: Interval between retries in milliseconds (default: INSTANCE_POLL_INTERVAL_MS)
+   */
+  public async waitForPort(waitOptions: WaitOptions): Promise<number> {
+    const port = waitOptions.portToCheck;
+    const tcpPort = this.container.getTcpPort(port);
+    const abortedSignal = new Promise(res => {
+      waitOptions.signal?.addEventListener('abort', () => {
+        res(true);
+      });
+    });
+    const pollInterval = waitOptions.waitInterval ?? INSTANCE_POLL_INTERVAL_MS;
+    let tries = waitOptions.retries ?? Math.ceil(TIMEOUT_TO_GET_PORTS_MS / pollInterval);
+
+    // Try to connect to the port multiple times
+    for (let i = 0; i < tries; i++) {
+      try {
+        const combinedSignal = addTimeoutSignal(waitOptions.signal, PING_TIMEOUT_MS);
+        await tcpPort.fetch('http://ping', { signal: combinedSignal });
+
+        // Successfully connected to this port
+        console.log(`Port ${port} is ready`);
+        break;
+      } catch (e) {
+        // Check for specific error messages that indicate we should keep retrying
+        const errorMessage = e instanceof Error ? e.message : String(e);
+
+        console.debug(`Error checking ${port}: ${errorMessage}`);
+
+        // If not running, it means the container crashed
+        if (!this.container.running) {
+          try {
+            await this.onError(
+              new Error(
+                `Container crashed while checking for ports, did you setup the entrypoint correctly?`
+              )
+            );
+          } catch {}
+
+          throw e;
+        }
+
+        // If we're on the last attempt and the port is still not ready, fail
+        if (i === tries - 1) {
+          try {
+            await this.onError(
+              `Failed to verify port ${port} is available after ${(i + 1) * pollInterval}ms, last error: ${errorMessage}`
+            );
+          } catch {}
+          throw e;
+        }
+
+        // Wait a bit before trying again
+        await Promise.any([
+          new Promise(resolve => setTimeout(resolve, waitOptions.waitInterval)),
+          abortedSignal,
+        ]);
+        if (waitOptions.signal?.aborted) {
+          throw new Error('Container request aborted.');
+        }
+      }
+    }
+    return tries;
+  }
   // =======================
   //     LIFECYCLE HOOKS
   // =======================
@@ -710,7 +725,7 @@ export class Container<Env = unknown> extends DurableObject<Env> {
       }
     }
 
-    const tcpPort = this.container.getTcpPort(port!);
+    const tcpPort = this.container.getTcpPort(port);
 
     // Create URL for the container request
     const containerUrl = request.url.replace('https:', 'http:');
@@ -809,7 +824,7 @@ export class Container<Env = unknown> extends DurableObject<Env> {
     requestOrUrl: Request | string | URL,
     portOrInit?: number | RequestInit,
     portParam?: number
-  ): { request: Request; port: number | undefined } {
+  ): { request: Request; port: number } {
     let request: Request;
     let port: number | undefined;
 
@@ -832,15 +847,13 @@ export class Container<Env = unknown> extends DurableObject<Env> {
       // Create a Request object
       request = new Request(url, init);
     }
-
+    port ??= this.defaultPort;
     // Require a port to be specified, either as a parameter or as a defaultPort property
-    if (port === undefined && this.defaultPort === undefined) {
+    if (port === undefined) {
       throw new Error(
         'No port specified for container fetch. Set defaultPort or specify a port parameter.'
       );
     }
-
-    port = port ?? this.defaultPort;
 
     return { request, port };
   }
@@ -882,13 +895,14 @@ export class Container<Env = unknown> extends DurableObject<Env> {
     }
 
     const abortedSignal = new Promise(res => {
-      waitOptions.abort?.addEventListener('abort', () => {
+      waitOptions.signal?.addEventListener('abort', () => {
         res(true);
       });
     });
-
+    const pollInterval = waitOptions.waitInterval ?? INSTANCE_POLL_INTERVAL_MS;
+    const totalTries = waitOptions.retries ?? Math.ceil(TIMEOUT_TO_GET_CONTAINER_MS / pollInterval);
     await this.state.setRunning();
-    for (let tries = 0; tries < waitOptions.retries; tries++) {
+    for (let tries = 0; tries < totalTries; tries++) {
       // Use provided options or fall back to instance properties
       const envVars = options?.envVars ?? this.envVars;
       const entrypoint = options?.entrypoint ?? this.entrypoint;
@@ -908,7 +922,7 @@ export class Container<Env = unknown> extends DurableObject<Env> {
 
         if (typeof err === 'number') {
           const toThrow = new Error(
-            `Error starting container, early exit code 0 before we could check for healthiness, did it crash early?`
+            `Container exited before we could determine the container health, exit code: ${err}`
           );
 
           try {
@@ -942,7 +956,7 @@ export class Container<Env = unknown> extends DurableObject<Env> {
       // TODO: Make this the port I'm trying to get!
       const port = this.container.getTcpPort(waitOptions.portToCheck);
       try {
-        const combinedSignal = addTimeoutSignal(waitOptions.abort, PING_TIMEOUT_MS);
+        const combinedSignal = addTimeoutSignal(waitOptions.signal, PING_TIMEOUT_MS);
         await port.fetch('http://containerstarthealthcheck', { signal: combinedSignal });
         return tries;
       } catch (error) {
@@ -964,15 +978,14 @@ export class Container<Env = unknown> extends DurableObject<Env> {
           abortedSignal,
         ]);
 
-        if (waitOptions.abort?.aborted) {
+        if (waitOptions.signal?.aborted) {
           throw new Error(
             'Aborted waiting for container to start as we received a cancellation signal'
           );
         }
 
-        // TODO: Don't hardcode to 3, use the max attempts
         // TODO: Make this error specific to this, but then catch it above w something else
-        if (TEMPORARY_HARDCODED_ATTEMPT_MAX === tries) {
+        if (totalTries === tries + 1) {
           if (error instanceof Error && error.message.includes('Network connection lost')) {
             // We have to abort here, the reasoning is that we might've found
             // ourselves in an internal error where the Worker is stuck with a failed connection to the
@@ -990,9 +1003,7 @@ export class Container<Env = unknown> extends DurableObject<Env> {
       }
     }
 
-    throw new Error(
-      `Container did not start after ${waitOptions.retries * waitOptions.waitInterval}ms`
-    );
+    throw new Error(`Container did not start after ${totalTries * pollInterval}ms`);
   }
 
   private setupMonitorCallbacks() {

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -416,19 +416,6 @@ export class Container<Env = unknown> extends DurableObject<Env> {
     // Determine which ports to check
     const portsToCheck = await this.getPortsToCheck(ports);
 
-    const state = await this.state.getState();
-
-    // if the container is already healthy and running, assume ports are ready
-    if (state.status === 'healthy' && this.container.running) {
-      if (this.container.running && !this.monitor) {
-        // This is needed to setup the monitoring
-        // Start the container if it's not running
-        this.monitor = this.container.monitor();
-        this.setupMonitorCallbacks();
-      }
-      return;
-    }
-
     // trigger all onStop that we didn't do yet
     await this.syncPendingStoppedEvents();
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,11 +73,18 @@ export interface CancellationOptions {
   waitInterval?: number;
 }
 
+/**
+ * Options for waitForPort()
+ */
 export interface WaitOptions {
-  abort?: AbortSignal;
-  retries: number;
-  waitInterval: number;
+  /** The port number to check for readiness */
   portToCheck: number;
+  /** Optional AbortSignal, use this to abort waiting for ports */
+  signal?: AbortSignal;
+  /** Number of attempts to wait for port to be ready */
+  retries?: number;
+  /** Time to wait in between polling port for readiness, in milliseconds */
+  waitInterval?: number;
 }
 
 /**


### PR DESCRIPTION
CC-5731

1. In startAndWaitForPorts, if the container had already been started, we didn't actually check if the ports are ready.
2. export a waitForPort method.
3. add waitOptions to start() for consistency