### PR TITLE
Add function overload to startAndWaitForPorts

### DIFF
--- a/.changeset/orange-keys-chew.md
+++ b/.changeset/orange-keys-chew.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/containers': patch
+---
+
+add function overload to startAndWaitForPorts()
+
+You can now use `startAndWaitForPorts({startOptions: {envVars: {FOO:"BAR"}}})` instead of `startAndWaitForPorts(undefined, {},  {envVars: {FOO:"BAR"}})`, although that is still supported.

--- a/example-node/src/index.ts
+++ b/example-node/src/index.ts
@@ -33,13 +33,10 @@ export default {
 
     if (pathname.startsWith('/startAndWaitForPorts')) {
       const containerInstance = getContainer(env.MY_CONTAINER, pathname);
-      await containerInstance.startAndWaitForPorts(
-        undefined,
-        {},
-        {
-          envVars: { MESSAGE: 'hi from start and wait for ports' },
-        }
-      );
+      await containerInstance.startAndWaitForPorts({
+        startOptions: { envVars: { MESSAGE: 'hi from start and wait for ports' } },
+      });
+
       return containerInstance.fetch(request);
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,7 +43,6 @@ export interface ContainerOptions {
   enableInternet?: boolean;
 }
 
-
 /**
  * Function to handle container events
  */
@@ -59,6 +58,19 @@ export interface ContainerStartConfigOptions {
   entrypoint?: string[];
   /** Whether to enable internet access for the container */
   enableInternet?: boolean;
+}
+
+export interface StartAndWaitForPortsOptions {
+  startOptions?: ContainerStartConfigOptions;
+  ports?: number | number[];
+  cancellationOptions?: CancellationOptions;
+}
+
+export interface CancellationOptions {
+  abort?: AbortSignal;
+  instanceGetTimeoutMS?: number;
+  portReadyTimeoutMS?: number;
+  waitInterval?: number;
 }
 
 export interface WaitOptions {


### PR DESCRIPTION
so you can now do `startAndWaitForPorts({envVars: {FOO:"bar"}) instead of `startAndWaitForPorts(undefined, {}, {envVars: {FOO:"bar"})`. 

also document it more completely (and also prettify README.md) 