### PR TITLE
next: cleanup fetch and start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,6 @@ export type {
   ContainerOptions,
   ContainerEventHandler,
   ContainerMessage,
-  ContainerStartConfigOptions,
   StopParams,
-  WaitOptions,
   State,
 } from './types';

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1,13 +1,4 @@
-import type {
-  ContainerOptions,
-  ContainerStartOptions,
-  ContainerStartConfigOptions,
-  StopParams,
-  State,
-  WaitOptions,
-  CancellationOptions,
-  StartAndWaitForPortsOptions,
-} from '../types';
+import type { ContainerOptions, ContainerStartOptions, StopParams, State } from '../types';
 import { parseTimeExpression } from './helpers';
 import { DurableObject } from 'cloudflare:workers';
 
@@ -32,12 +23,6 @@ const INSTANCE_POLL_INTERVAL_MS = 300; // Default interval for polling container
 // Timeout for getting container instance and launching a VM
 // Time to find an instance, attach a DO, call start, but NOT
 // the time for the app the actually start
-const TIMEOUT_TO_GET_CONTAINER_MS = 8_000;
-
-// Timeout for getting a container instance and launching
-// the actual application and have it listen for specific ports
-// One day might be configurable by the end user in Container class attribute
-const TIMEOUT_TO_GET_PORTS_MS = 20_000;
 
 // If user has specified no ports and we need to check one
 // to see if the container is up at all.
@@ -106,20 +91,15 @@ function getExitCodeFromError(error: unknown): number | null {
 function addTimeoutSignal(existingSignal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
   const controller = new AbortController();
 
-  // Forward existing signal abort
-  if (existingSignal?.aborted) {
-    controller.abort();
-    return controller.signal;
-  }
-
   existingSignal?.addEventListener('abort', () => controller.abort());
 
   // Add timeout
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const timeoutId = setTimeout(() => controller.abort('ping timed out'), timeoutMs);
 
   // Clean up timeout if signal is aborted early
   controller.signal.addEventListener('abort', () => clearTimeout(timeoutId));
 
+  // note the timeout aborting does not clear the existing signal
   return controller.signal;
 }
 
@@ -202,10 +182,6 @@ export class Container<Env = unknown> extends DurableObject<Env> {
   // Default port for the container (undefined means no default port)
   defaultPort?: number;
 
-  // Required ports that should be checked for availability during container startup
-  // Override this in your subclass to specify ports that must be ready
-  requiredPorts?: number[];
-
   // Timeout after which the container will sleep if no activity
   // The signal sent to the container by default is a SIGTERM.
   // The container won't get a SIGKILL if this threshold is triggered.
@@ -258,217 +234,121 @@ export class Container<Env = unknown> extends DurableObject<Env> {
     return { ...(await this.state.getState()) };
   }
 
-  // ==========================
-  //     CONTAINER STARTING
-  // ==========================
-
   /**
-   * Start the container if it's not running and set up monitoring and lifecycle hooks,
-   * without waiting for ports to be ready.
    *
-   * It will automatically retry if the container fails to start, using the specified waitOptions
+   * Starts container.
+   * If the container is already started, and waitForReady is false, this will resolve immediately if the container accepts the ping.
    *
-   *
-   * @example
-   * await this.start({
-   *   envVars: { DEBUG: 'true', NODE_ENV: 'development' },
-   *   entrypoint: ['npm', 'run', 'dev'],
-   *   enableInternet: false
-   * });
-   *
-   * @param startOptions - Override `envVars`, `entrypoint` and `enableInternet` on a per-instance basis
-   * @param waitOptions - Optional wait configuration with abort signal for cancellation. Default ~8s timeout.
-   * @returns A promise that resolves when the container start command has been issued
-   * @throws Error if no container context is available or if all start attempts fail
    */
-  public async start(
-    startOptions?: ContainerStartConfigOptions,
-    waitOptions?: WaitOptions
-  ): Promise<void> {
-    const portToCheck =
-      waitOptions?.portToCheck ??
-      this.defaultPort ??
-      (this.requiredPorts ? this.requiredPorts[0] : FALLBACK_PORT_TO_CHECK);
-    const pollInterval = waitOptions?.waitInterval ?? INSTANCE_POLL_INTERVAL_MS;
-    await this.startContainerIfNotRunning(
-      {
-        signal: waitOptions?.signal,
-        waitInterval: pollInterval,
-        retries: waitOptions?.retries ?? Math.ceil(TIMEOUT_TO_GET_CONTAINER_MS / pollInterval),
-        portToCheck,
-      },
-      startOptions
-    );
-
-    this.setupMonitorCallbacks();
-
-    // TODO: We should consider an onHealthy callback
-    await this.ctx.blockConcurrencyWhile(async () => {
-      await this.onStart();
-    });
-  }
-
-  /**
-   * Start the container and wait for ports to be available.
-   *
-   * For each specified port, it polls until the port is available or `cancellationOptions.portReadyTimeoutMS` is reached.
-   *
-   * @param ports - The ports to wait for (if undefined, uses requiredPorts or defaultPort)
-   * @param cancellationOptions - Options to configure timeouts, polling intereva, and abort signal
-   * @param startOptions Override configuration on a per-instance basis for env vars, entrypoint command and internet access
-   * @returns A promise that resolves when the container has been started and the ports are listening
-   * @throws Error if port checks fail after the specified timeout or if the container fails to start.
-   */
-  public async startAndWaitForPorts(args: StartAndWaitForPortsOptions): Promise<void>;
-  public async startAndWaitForPorts(
-    ports?: number | number[],
-    cancellationOptions?: CancellationOptions,
-    startOptions?: ContainerStartConfigOptions
-  ): Promise<void>;
-  public async startAndWaitForPorts(
-    portsOrArgs?: number | number[] | StartAndWaitForPortsOptions,
-    cancellationOptions?: CancellationOptions,
-    startOptions?: ContainerStartConfigOptions
-  ): Promise<void>;
-  public async startAndWaitForPorts(
-    portsOrArgs?: number | number[] | StartAndWaitForPortsOptions,
-    cancellationOptions?: CancellationOptions,
-    startOptions?: ContainerStartConfigOptions
-  ): Promise<void> {
-    // Parse arguments to handle different overload signatures
-    let ports: number | number[] | undefined;
-    let resolvedCancellationOptions: CancellationOptions | undefined = {};
-    let resolvedStartOptions: ContainerStartConfigOptions | undefined = {};
-
-    if (typeof portsOrArgs === 'object' && portsOrArgs !== null && !Array.isArray(portsOrArgs)) {
-      // Object-based overload: { startOptions?, ports?, cancellationOptions? }
-      ports = portsOrArgs.ports;
-      resolvedCancellationOptions = portsOrArgs.cancellationOptions;
-      resolvedStartOptions = portsOrArgs.startOptions;
-    } else {
-      ports = portsOrArgs;
-      resolvedCancellationOptions = cancellationOptions;
-      resolvedStartOptions = startOptions;
-    }
-
-    // Determine which ports to check
-    const portsToCheck = await this.getPortsToCheck(ports);
-
-    // Prepare to start the container
-    resolvedCancellationOptions ??= {};
-    const containerGetTimeout =
-      resolvedCancellationOptions.instanceGetTimeoutMS ?? TIMEOUT_TO_GET_CONTAINER_MS;
-    const pollInterval = resolvedCancellationOptions.waitInterval ?? INSTANCE_POLL_INTERVAL_MS;
-    let containerGetRetries = Math.ceil(containerGetTimeout / pollInterval);
-
-    const waitOptions: WaitOptions = {
-      signal: resolvedCancellationOptions.abort,
-      retries: containerGetRetries,
-      waitInterval: pollInterval,
-      portToCheck: portsToCheck[0],
+  public async start(options: {
+    /** Environment variables to pass to the container */
+    envVars?: Record<string, string>;
+    /** Custom entrypoint to override container default */
+    entrypoint?: string[];
+    /** Whether to enable internet access for the container */
+    enableInternet?: boolean;
+    signal?: AbortSignal;
+    // whether to wait for the application inside the container to be ready
+    waitForReady?: boolean;
+    retryOptions?: {
+      retries?: number;
+      intervalMs?: number;
+      pingTimeoutMs?: number;
     };
-
-    // Start the container if it's not running
-    const triesUsed = await this.startContainerIfNotRunning(waitOptions, resolvedStartOptions);
-
-    // Check each port
-
-    const totalPortReadyTries = Math.ceil(
-      resolvedCancellationOptions.portReadyTimeoutMS ?? TIMEOUT_TO_GET_PORTS_MS / pollInterval
-    );
-    let triesLeft = totalPortReadyTries - triesUsed;
-
-    for (const port of portsToCheck) {
-      triesLeft = await this.waitForPort({
-        signal: resolvedCancellationOptions.abort,
-        waitInterval: pollInterval,
-        retries: triesLeft,
-        portToCheck: port,
-      });
+    portToCheck?: number;
+  }): Promise<void> {
+    options.waitForReady ??= true;
+    if (this.container.running && options.waitForReady === false) {
+      console.log('should not be here');
+      return;
     }
 
-    this.setupMonitorCallbacks();
+    options.retryOptions ??= {};
+    options.retryOptions.retries ??= 6;
+    options.retryOptions.intervalMs ??= INSTANCE_POLL_INTERVAL_MS;
+    options.retryOptions.pingTimeoutMs ??= PING_TIMEOUT_MS;
 
-    await this.ctx.blockConcurrencyWhile(async () => {
-      // All ports are ready
-      await this.state.setHealthy();
-      await this.onStart();
-    });
-  }
-
-  /**
-   *
-   * Waits for a specified port to be ready
-   *
-   * Returns the number of tries used to get the port, or throws if it couldn't get the port within the specified retry limits.
-   *
-   * @param waitOptions -
-   * - `portToCheck`: The port number to check
-   * - `abort`: Optional AbortSignal to cancel waiting
-   * - `retries`: Number of retries before giving up (default: TRIES_TO_GET_PORTS)
-   * - `waitInterval`: Interval between retries in milliseconds (default: INSTANCE_POLL_INTERVAL_MS)
-   */
-  public async waitForPort(waitOptions: WaitOptions): Promise<number> {
-    const port = waitOptions.portToCheck;
-    const tcpPort = this.container.getTcpPort(port);
-    const abortedSignal = new Promise(res => {
-      waitOptions.signal?.addEventListener('abort', () => {
-        res(true);
+    // race timeout against this
+    const userAbortSignal = new Promise<void>(res => {
+      options.signal?.addEventListener('abort', () => {
+        res();
       });
     });
-    const pollInterval = waitOptions.waitInterval ?? INSTANCE_POLL_INTERVAL_MS;
-    let tries = waitOptions.retries ?? Math.ceil(TIMEOUT_TO_GET_PORTS_MS / pollInterval);
 
-    // Try to connect to the port multiple times
-    for (let i = 0; i < tries; i++) {
-      try {
-        const combinedSignal = addTimeoutSignal(waitOptions.signal, PING_TIMEOUT_MS);
-        await tcpPort.fetch('http://ping', { signal: combinedSignal });
+    const portToCheck = options.portToCheck ?? this.defaultPort ?? FALLBACK_PORT_TO_CHECK;
 
-        // Successfully connected to this port
-        console.log(`Port ${port} is ready`);
-        break;
-      } catch (e) {
-        // Check for specific error messages that indicate we should keep retrying
-        const errorMessage = e instanceof Error ? e.message : String(e);
-
-        console.debug(`Error checking ${port}: ${errorMessage}`);
-
-        // If not running, it means the container crashed
-        if (!this.container.running) {
-          try {
-            await this.onError(
-              new Error(
-                `Container crashed while checking for ports, did you start the container and setup the entrypoint correctly?`
-              )
-            );
-          } catch {}
-
-          throw e;
-        }
-
-        // If we're on the last attempt and the port is still not ready, fail
-        if (i === tries - 1) {
-          try {
-            await this.onError(
-              `Failed to verify port ${port} is available after ${(i + 1) * pollInterval}ms, last error: ${errorMessage}`
-            );
-          } catch {}
-          throw e;
-        }
-
-        // Wait a bit before trying again
-        await Promise.any([
-          new Promise(resolve => setTimeout(resolve, waitOptions.waitInterval)),
-          abortedSignal,
-        ]);
-        if (waitOptions.signal?.aborted) {
-          throw new Error('Container request aborted.');
+    let attempt = 0;
+    let retryStart = false;
+    let initiallyRunning = this.container.running;
+    while (attempt < options.retryOptions.retries) {
+      if (options.signal?.aborted) {
+        throw new Error('Container start aborted');
+      }
+      if (!this.container.running && (attempt === 0 || retryStart)) {
+        const resolvedEnvVars = options.envVars ?? this.envVars;
+        const resolvedEntrypoint = options.entrypoint ?? this.entrypoint;
+        this.container.start({
+          ...(resolvedEnvVars && { env: resolvedEnvVars }),
+          ...(resolvedEntrypoint && { entrypoint: resolvedEntrypoint }),
+          enableInternet: options.enableInternet ?? this.enableInternet, // defaults to true
+        });
+        retryStart = false;
+        if (!this.monitor) {
+          this.monitor = this.container.monitor();
         }
       }
+
+      const combinedSignal = addTimeoutSignal(options.signal, options.retryOptions.pingTimeoutMs);
+      try {
+        // in the future this could be a user defined healthcheck
+        await this.container
+          .getTcpPort(portToCheck)
+          .fetch('http://ping', { signal: combinedSignal });
+        if (initiallyRunning === false) {
+          await this.onStart();
+        }
+        return;
+      } catch (e) {
+        if (this.container.running) {
+          if (!options.waitForReady && !isNotListeningError(e)) {
+            return;
+          }
+        } else {
+          await this.monitor?.catch(err => {
+            // this is the only case where we want to retry,
+            // as a new instance might become available
+            if (isNoInstanceError(err)) {
+              retryStart = true;
+            } else {
+              // assume the container crashed and give up
+              throw err;
+            }
+          });
+        }
+
+        console.debug('Container was not ready:', e instanceof Error ? e.message : String(e));
+        attempt++;
+        if (attempt >= options.retryOptions.retries) {
+          if (e instanceof Error && e.message.includes('Network connection lost')) {
+            // We have to abort here, the reasoning is that we might've found
+            // ourselves in an internal error where the Worker is stuck with a failed connection to the
+            // container services.
+            //
+            // Until we address this issue on the back-end CF side, we will need to abort the
+            // durable object so it retries to reconnect from scratch.
+            this.ctx.abort();
+          }
+          // we are out of retries
+          throw new Error(NO_CONTAINER_INSTANCE_ERROR);
+        }
+      }
+      await Promise.race([
+        new Promise(res => setTimeout(res, options.retryOptions?.intervalMs)),
+        userAbortSignal,
+      ]);
     }
-    return tries;
   }
+
   // =======================
   //     LIFECYCLE HOOKS
   // =======================
@@ -534,25 +414,8 @@ export class Container<Env = unknown> extends DurableObject<Env> {
       );
     }
 
-    // start container
-    // TODO: check if in process of starting already...?
-    if (!this.container.running) {
-      try {
-        await this.startAndWaitForPorts(targetPort, { abort: request.signal });
-      } catch (e) {
-        if (isNoInstanceError(e)) {
-          return new Response(
-            'There is no Container instance available at this time.\nThis is likely because you have reached your max concurrent instance count (set in wrangler config) or are you currently provisioning the Container.\nIf you are deploying your Container for the first time, check your dashboard to see provisioning status, this may take a few minutes.',
-            { status: 503 }
-          );
-        } else {
-          return new Response(
-            `Failed to start container: ${e instanceof Error ? e.message : String(e)}`,
-            { status: 500 }
-          );
-        }
-      }
-    }
+    // should this ping the container if running already?
+    await this.start({ portToCheck: targetPort, waitForReady: true, signal: request.signal });
 
     const tcpPort = this.container.getTcpPort(targetPort);
 
@@ -583,124 +446,6 @@ export class Container<Env = unknown> extends DurableObject<Env> {
    * Tries to start a container if it's not already running
    * Returns the number of tries used
    */
-  private async startContainerIfNotRunning(
-    waitOptions: WaitOptions,
-    options?: ContainerStartConfigOptions
-  ): Promise<number> {
-    // Start the container if it's not running
-    if (this.container.running) {
-      if (!this.monitor) {
-        this.monitor = this.container.monitor();
-      }
-
-      return 0;
-    }
-
-    const abortedSignal = new Promise(res => {
-      waitOptions.signal?.addEventListener('abort', () => {
-        res(true);
-      });
-    });
-    const pollInterval = waitOptions.waitInterval ?? INSTANCE_POLL_INTERVAL_MS;
-    const totalTries = waitOptions.retries ?? Math.ceil(TIMEOUT_TO_GET_CONTAINER_MS / pollInterval);
-    await this.state.setRunning();
-    for (let tries = 0; tries < totalTries; tries++) {
-      // Use provided options or fall back to instance properties
-      const envVars = options?.envVars ?? this.envVars;
-      const entrypoint = options?.entrypoint ?? this.entrypoint;
-      const enableInternet = options?.enableInternet ?? this.enableInternet;
-
-      // Only include properties that are defined
-      const startConfig: ContainerStartOptions = {
-        enableInternet,
-      };
-
-      if (envVars && Object.keys(envVars).length > 0) startConfig.env = envVars;
-      if (entrypoint) startConfig.entrypoint = entrypoint;
-
-      const handleError = async () => {
-        const err = await this.monitor?.catch(err => err as Error);
-
-        if (typeof err === 'number') {
-          const toThrow = new Error(
-            `Container exited before we could determine the container health, exit code: ${err}`
-          );
-
-          try {
-            await this.onError(toThrow);
-          } catch {}
-
-          throw toThrow;
-        } else if (!isNoInstanceError(err)) {
-          try {
-            await this.onError(err);
-          } catch {}
-
-          throw err;
-        }
-      };
-
-      if (!this.container.running) {
-        if (tries > 0) {
-          await handleError();
-        }
-
-        this.container.start(startConfig);
-        this.monitor = this.container.monitor();
-      }
-
-      // TODO: Make this the port I'm trying to get!
-      const port = this.container.getTcpPort(waitOptions.portToCheck);
-      try {
-        const combinedSignal = addTimeoutSignal(waitOptions.signal, PING_TIMEOUT_MS);
-        await port.fetch('http://containerstarthealthcheck', { signal: combinedSignal });
-        return tries;
-      } catch (error) {
-        if (isNotListeningError(error) && this.container.running) {
-          return tries;
-        }
-
-        if (!this.container.running && isNotListeningError(error)) {
-          await handleError();
-        }
-
-        console.debug(
-          'Error checking if container is ready:',
-          error instanceof Error ? error.message : String(error)
-        );
-
-        await Promise.any([
-          new Promise(res => setTimeout(res, waitOptions.waitInterval)),
-          abortedSignal,
-        ]);
-
-        if (waitOptions.signal?.aborted) {
-          throw new Error(
-            'Aborted waiting for container to start as we received a cancellation signal'
-          );
-        }
-
-        // TODO: Make this error specific to this, but then catch it above w something else
-        if (totalTries === tries + 1) {
-          if (error instanceof Error && error.message.includes('Network connection lost')) {
-            // We have to abort here, the reasoning is that we might've found
-            // ourselves in an internal error where the Worker is stuck with a failed connection to the
-            // container services.
-            //
-            // Until we address this issue on the back-end CF side, we will need to abort the
-            // durable object so it retries to reconnect from scratch.
-            this.ctx.abort();
-          }
-
-          throw new Error(NO_CONTAINER_INSTANCE_ERROR);
-        }
-
-        continue;
-      }
-    }
-
-    throw new Error(`Container did not start after ${totalTries * pollInterval}ms`);
-  }
 
   // TODO: we may need to update this to work with setinactivityTimeout
   private setupMonitorCallbacks() {

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -20,10 +20,6 @@ const PING_TIMEOUT_MS = 5000;
 const DEFAULT_SLEEP_AFTER = '10m'; // Default sleep after inactivity time
 const INSTANCE_POLL_INTERVAL_MS = 300; // Default interval for polling container state
 
-// Timeout for getting container instance and launching a VM
-// Time to find an instance, attach a DO, call start, but NOT
-// the time for the app the actually start
-
 // If user has specified no ports and we need to check one
 // to see if the container is up at all.
 const FALLBACK_PORT_TO_CHECK = 33;
@@ -259,7 +255,6 @@ export class Container<Env = unknown> extends DurableObject<Env> {
   }): Promise<void> {
     options.waitForReady ??= true;
     if (this.container.running && options.waitForReady === false) {
-      console.log('should not be here');
       return;
     }
 
@@ -414,7 +409,6 @@ export class Container<Env = unknown> extends DurableObject<Env> {
       );
     }
 
-    // should this ping the container if running already?
     await this.start({ portToCheck: targetPort, waitForReady: true, signal: request.signal });
 
     const tcpPort = this.container.getTcpPort(targetPort);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,50 +49,6 @@ export interface ContainerOptions {
 export type ContainerEventHandler = () => void | Promise<void>;
 
 /**
- * Options for starting a container with specific configuration
- */
-export interface ContainerStartConfigOptions {
-  /** Environment variables to pass to the container */
-  envVars?: Record<string, string>;
-  /** Custom entrypoint to override container default */
-  entrypoint?: string[];
-  /** Whether to enable internet access for the container */
-  enableInternet?: boolean;
-}
-
-export interface StartAndWaitForPortsOptions {
-  startOptions?: ContainerStartConfigOptions;
-  ports?: number | number[];
-  cancellationOptions?: CancellationOptions;
-}
-
-/** cancellationOptions for startAndWaitForPorts()  */
-export interface CancellationOptions {
-  /** abort signal, use to abort startAndWaitForPorts manually. */
-  abort?: AbortSignal;
-  /** max time to get container instance and start it (application inside may not be ready), in milliseconds */
-  instanceGetTimeoutMS?: number;
-  /** max time to wait for application to be listening at all specified ports, in milliseconds. */
-  portReadyTimeoutMS?: number;
-  /** time to wait between polling, in milliseconds */
-  waitInterval?: number;
-}
-
-/**
- * Options for waitForPort()
- */
-export interface WaitOptions {
-  /** The port number to check for readiness */
-  portToCheck: number;
-  /** Optional AbortSignal, use this to abort waiting for ports */
-  signal?: AbortSignal;
-  /** Number of attempts to wait for port to be ready */
-  retries?: number;
-  /** Time to wait in between polling port for readiness, in milliseconds */
-  waitInterval?: number;
-}
-
-/**
  * Params sent to `onStop` method when the container stops
  */
 export type StopParams = {


### PR DESCRIPTION
commit 1:
containerFetch and fetch are now just fetch.
not entirely sure how to ban users from overriding fetch. i don't think we can do that in typescript alone. 

commit 2:
combine start, startAndWaitForPorts, startContainerIfNotRunning and waitForPorts into one function. 

also removes 'requiredPorts' where we check all of these on start up. i don't think we should commit to this - we should make this call a user provided health check hook instead where we ping the container. 

i noticed that the error strings we're matching on don't exist in the local implementation  - we should either add them in and/or reconsider if there is a more robust way to do this other than string matching 

todo:
- [ ] put all the onError calls back in
 
