### PR TITLE
containers: Add labels support to start options

### DIFF
--- a/.changeset/start-labels.md
+++ b/.changeset/start-labels.md
@@ -1,0 +1,11 @@
+---
+'@cloudflare/containers': patch
+---
+
+Attach custom labels to your containers to help with observability and attribution. Set a `labels` property on your `Container` subclass, or pass `labels` in the `startOptions` argument to `start()` / `startAndWaitForPorts()`, and tag containers by tenant, environment, feature flag, canary cohort, or any other dimension you want to track. In local development, labels are visible on the underlying Docker container via `docker inspect`.
+
+```ts
+class MyContainer extends Container {
+  labels = { tenant: 'acme', env: 'prod' };
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@cloudflare/containers",
-  "version": "0.2.3",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/containers",
-      "version": "0.2.3",
+      "version": "0.3.2",
       "license": "ISC",
       "devDependencies": {
         "@changesets/cli": "^2.29.6",
-        "@cloudflare/workers-types": "^4.20260405.1",
+        "@cloudflare/workers-types": "^4.20260421.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.3",
         "@typescript-eslint/eslint-plugin": "^8.31.1",
@@ -873,9 +873,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260405.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
-      "integrity": "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==",
+      "version": "4.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260421.1.tgz",
+      "integrity": "sha512-PJjuz1zwwa+/WP9dkf5ORMQWL7u2m1d8aFUhG3dx6ohweGd+zMppT1JG0zhc00LUg8gFXVaiZzZ5w/0Cp4HI+g==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -10156,9 +10156,9 @@
       }
     },
     "@cloudflare/workers-types": {
-      "version": "4.20260405.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
-      "integrity": "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==",
+      "version": "4.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260421.1.tgz",
+      "integrity": "sha512-PJjuz1zwwa+/WP9dkf5ORMQWL7u2m1d8aFUhG3dx6ohweGd+zMppT1JG0zhc00LUg8gFXVaiZzZ5w/0Cp4HI+g==",
       "dev": true
     },
     "@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "license": "ISC",
   "devDependencies": {
     "@changesets/cli": "^2.29.6",
-    "@cloudflare/workers-types": "^4.20260405.1",
+    "@cloudflare/workers-types": "^4.20260421.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.3",
     "@typescript-eslint/eslint-plugin": "^8.31.1",

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -487,6 +487,7 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
   envVars: ContainerStartOptions['env'] = {};
   entrypoint: ContainerStartOptions['entrypoint'];
   enableInternet: ContainerStartOptions['enableInternet'] = true;
+  labels: ContainerStartOptions['labels'] = {};
 
   // When true, outbound HTTPS traffic from the container will be intercepted.
   // The container must trust /etc/cloudflare/certs/cloudflare-containers-ca.crt
@@ -758,10 +759,11 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
    * await this.start({
    *   envVars: { DEBUG: 'true', NODE_ENV: 'development' },
    *   entrypoint: ['npm', 'run', 'dev'],
-   *   enableInternet: false
+   *   enableInternet: false,
+   *   labels: { tenant: 'acme', env: 'prod' },
    * });
    *
-   * @param startOptions - Override `envVars`, `entrypoint` and `enableInternet` on a per-instance basis
+   * @param startOptions - Override `envVars`, `entrypoint`, `enableInternet` and `labels` on a per-instance basis
    * @param waitOptions - Optional wait configuration with abort signal for cancellation. Default ~8s timeout.
    * @returns A promise that resolves when the container start command has been issued
    * @throws Error if no container context is available or if all start attempts fail
@@ -800,7 +802,7 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
    *
    * @param ports - The ports to wait for (if undefined, uses requiredPorts or defaultPort)
    * @param cancellationOptions - Options to configure timeouts, polling intereva, and abort signal
-   * @param startOptions Override configuration on a per-instance basis for env vars, entrypoint command and internet access
+   * @param startOptions Override configuration on a per-instance basis for env vars, entrypoint command, internet access, and labels
    * @returns A promise that resolves when the container has been started and the ports are listening
    * @throws Error if port checks fail after the specified timeout or if the container fails to start.
    */
@@ -1702,6 +1704,7 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
       const envVars = options?.envVars ?? this.envVars;
       const entrypoint = options?.entrypoint ?? this.entrypoint;
       const enableInternet = options?.enableInternet ?? this.enableInternet;
+      const labels = options?.labels ?? this.labels;
       // TODO: hopefully, enableInternet can be false in a future where we enable DNS
       // and TLS paths.
 
@@ -1712,6 +1715,7 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
 
       if (envVars && Object.keys(envVars).length > 0) startConfig.env = envVars;
       if (entrypoint) startConfig.entrypoint = entrypoint;
+      if (labels && Object.keys(labels).length > 0) startConfig.labels = labels;
 
       this.renewActivityTimeout();
       const handleError = async () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,8 @@ export interface ContainerStartConfigOptions {
   entrypoint?: string[];
   /** Whether to enable internet access for the container */
   enableInternet?: boolean;
+  /** Key-value metadata labels attached to the container for metrics/observability */
+  labels?: Record<string, string>;
 }
 
 export interface StartAndWaitForPortsOptions {


### PR DESCRIPTION
cloudflare/workerd#6352 lets `ctx.container.start()` take a `labels` field, but the `Container` class doesn't expose a way to set it, so library users can't. Added `labels` instance property with per-invocation overrides via `startOptions.labels` (same pattern as `envVars` / `entrypoint` / `enableInternet`).

`@cloudflare/workers-types` bumped so `ContainerStartupOptions.labels` is visible in TS.
