### PR TITLE
containers: Honor subclass sleepAfter override during initial activity setup

### DIFF
--- a/.changeset/subclass-sleepafter-init.md
+++ b/.changeset/subclass-sleepafter-init.md
@@ -1,0 +1,13 @@
+---
+'@cloudflare/containers': patch
+---
+
+Fix subclass `sleepAfter` overrides being ignored during the initial activity timeout setup. Previously, the base `Container` constructor called `renewActivityTimeout()` inside `blockConcurrencyWhile()` before subclass class-field initializers ran, so the first `sleepAfterMs` was always computed from the base default (`'10m'`) regardless of whether the subclass declared `sleepAfter = '2h'`. A container could then be killed by the activity timeout before the subclass's longer window took effect on the next `renewActivityTimeout` call. Declarations like:
+
+```ts
+class BigContainer extends Container {
+  sleepAfter = '2h';
+}
+```
+
+are now honored from the very first alarm check.

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -529,10 +529,11 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
 
     const persistedOutboundConfiguration = this.restoreOutboundConfiguration();
     this.ctx.blockConcurrencyWhile(async () => {
-      this.renewActivityTimeout();
-
-      // First thing, schedule the next alarms
+      // First thing, schedule the next alarms. Also yields a microtask
+      // so subclass class-field initializers (e.g. `sleepAfter = "2h"`)
+      // run before renewActivityTimeout reads `this.sleepAfter`.
       await this.scheduleNextAlarm();
+      this.renewActivityTimeout();
 
       const ctor = this.constructor as typeof Container;
       if (


### PR DESCRIPTION
Fixes #127.

## Root cause

Subclass class-field initializers (`sleepAfter = '2h'`) run after the base class constructor returns. The base constructor calls `renewActivityTimeout()` synchronously inside its `blockConcurrencyWhile` callback, at a point where `this.sleepAfter` is still the base default (`'10m'`). The initial `sleepAfterMs` is therefore always computed from the default, not the subclass override.

Reported timeline in #127 (`sleepAfter = '2h'`, container sleeps after 1–2 minutes) is consistent with this: the first alarm fires inside the 10-minute base-default window before any `containerFetch` has had a chance to call `renewActivityTimeout()` with the correct value.

## Fix

Swap two statements in the constructor's `blockConcurrencyWhile` callback so `scheduleNextAlarm()` runs before `renewActivityTimeout()`:

```ts
// before
this.renewActivityTimeout();
await this.scheduleNextAlarm();

// after
await this.scheduleNextAlarm();
this.renewActivityTimeout();
```

The `await` yields a microtask, during which `super()` returns and subclass class-field initializers run. By the time `renewActivityTimeout()` executes, `this.sleepAfter` is the subclass-overridden value. `scheduleNextAlarm` doesn't depend on `sleepAfterMs`, so the reorder is safe.

## Tests

Verified locally against a red/green cycle with a targeted Jest test that constructs a subclass with `sleepAfter = '2h'`, awaits the constructor's `blockConcurrencyWhile` promise, and asserts `sleepAfterMs` is ~2h out. Not included here because the Jest harness in this repo currently lives alongside #191's test infrastructure — once either this PR or #191 lands, the regression can be pinned in a follow-up. Happy to include the test if you'd prefer the harness land with this PR.
