### PR TITLE
preserve startup rate-limit signals

### DIFF
--- a/.changeset/tame-eggs-exist.md
+++ b/.changeset/tame-eggs-exist.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/containers': patch
+---
+
+Preserve Cloudchamber startup rate-limit errors in the Containers helper and return HTTP 429 from `containerFetch()` when startup is rate limited.

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1795,8 +1795,6 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
 
         // TODO: Make this error specific to this, but then catch it above w something else
         if (totalTries === tries + 1) {
-          await handleError();
-
           if (error instanceof Error && error.message.includes('Network connection lost')) {
             // We have to abort here, the reasoning is that we might've found
             // ourselves in an internal error where the Worker is stuck with a failed connection to the
@@ -1806,6 +1804,8 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
             // durable object so it retries to reconnect from scratch.
             this.ctx.abort();
           }
+
+          await handleError();
 
           throw new Error(NO_CONTAINER_INSTANCE_ERROR);
         }

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -21,6 +21,7 @@ import { DurableObject, WorkerEntrypoint } from 'cloudflare:workers';
 
 const NO_CONTAINER_INSTANCE_ERROR =
   'there is no container instance that can be provided to this durable object';
+const RATE_LIMITED_ERROR = 'you are requesting too many containers per second';
 const RUNTIME_SIGNALLED_ERROR = 'runtime signalled the container to exit:';
 const UNEXPECTED_EXIT_ERROR = 'container exited with unexpected exit code:';
 const NOT_LISTENING_ERROR = 'the container is not listening';
@@ -141,6 +142,7 @@ function isErrorOfType(e: unknown, matchingString: string): boolean {
 
 const isNoInstanceError = (error: unknown): boolean =>
   isErrorOfType(error, NO_CONTAINER_INSTANCE_ERROR);
+const isRateLimitedError = (error: unknown): boolean => isErrorOfType(error, RATE_LIMITED_ERROR);
 const isRuntimeSignalledError = (error: unknown): boolean =>
   isErrorOfType(error, RUNTIME_SIGNALLED_ERROR);
 const isNotListeningError = (error: unknown): boolean => isErrorOfType(error, NOT_LISTENING_ERROR);
@@ -1169,12 +1171,15 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
             'There is no Container instance available at this time.\nThis is likely because you have reached your max concurrent instance count (set in wrangler config) or are you currently provisioning the Container.\nIf you are deploying your Container for the first time, check your dashboard to see provisioning status, this may take a few minutes.',
             { status: 503 }
           );
-        } else {
-          return new Response(
-            `Failed to start container: ${e instanceof Error ? e.message : String(e)}`,
-            { status: 500 }
-          );
         }
+
+        if (isRateLimitedError(e)) {
+          return new Response(e instanceof Error ? e.message : String(e), { status: 429 });
+        }
+
+        return new Response(`Failed to start container: ${e instanceof Error ? e.message : String(e)}`, {
+          status: 500,
+        });
       }
     }
 
@@ -1790,6 +1795,8 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
 
         // TODO: Make this error specific to this, but then catch it above w something else
         if (totalTries === tries + 1) {
+          await handleError();
+
           if (error instanceof Error && error.message.includes('Network connection lost')) {
             // We have to abort here, the reasoning is that we might've found
             // ourselves in an internal error where the Worker is stuck with a failed connection to the

--- a/src/tests/container.test.ts
+++ b/src/tests/container.test.ts
@@ -1,6 +1,25 @@
 // Mock partyserver first
 jest.mock('partyserver');
 
+jest.mock('cloudflare:workers', () => {
+  class MockDurableObject {
+    ctx: unknown;
+    env: unknown;
+
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+  }
+
+  class MockWorkerEntrypoint {}
+
+  return {
+    DurableObject: MockDurableObject,
+    WorkerEntrypoint: MockWorkerEntrypoint,
+  };
+}, { virtual: true });
+
 import { Container } from '../lib/container';
 import { getRandom } from '../lib/utils';
 
@@ -44,6 +63,16 @@ describe('Container', () => {
     // Create a mock context with necessary container methods
     mockCtx = {
       storage: {
+        get: jest.fn(),
+        put: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+        setAlarm: jest.fn().mockResolvedValue(undefined),
+        sync: jest.fn().mockResolvedValue(undefined),
+        kv: {
+          get: jest.fn(),
+          put: jest.fn().mockResolvedValue(undefined),
+          delete: jest.fn().mockResolvedValue(undefined),
+        },
         sql: {
           exec: jest.fn().mockReturnValue([]),
         },
@@ -127,6 +156,23 @@ describe('Container', () => {
     expect(mockCtx.container.getTcpPort).toHaveBeenCalledWith(8080);
   });
 
+  test('startAndWaitForPorts should surface rate-limited startup errors on the final retry', async () => {
+    mockCtx.container.monitor = jest.fn().mockReturnValue({
+      catch: jest.fn().mockResolvedValue(new Error('you are requesting too many containers per second')),
+    });
+    mockCtx.container.getTcpPort = jest.fn().mockReturnValue({
+      fetch: jest.fn().mockRejectedValue(new Error('unexpected startup failure')),
+    });
+
+    await expect(
+      // @ts-ignore - ignore TypeScript errors for testing
+      container.startAndWaitForPorts({
+        ports: 8080,
+        cancellationOptions: { instanceGetTimeoutMS: 1, waitInterval: 1 },
+      })
+    ).rejects.toThrow('you are requesting too many containers per second');
+  });
+
   test('startAndWaitForPorts should start container without port checking if no ports available', async () => {
     // Create a container without defaultPort or requiredPorts
     // @ts-ignore - ignore TypeScript errors for testing
@@ -173,6 +219,20 @@ describe('Container', () => {
 
     // Just make sure that tcpPort.fetch was called - the exact URL is tested in the container.ts implementation
     expect(tcpPort.fetch).toHaveBeenCalledWith(expect.any(String), expect.any(Object));
+  });
+
+  test('containerFetch should return 429 when startup is rate limited', async () => {
+    const mockRequest = new Request('https://example.com/test', { method: 'GET' });
+    const startSpy = jest
+      .spyOn(container, 'startAndWaitForPorts')
+      .mockRejectedValue(new Error('you are requesting too many containers per second'));
+
+    // @ts-ignore - ignore TypeScript errors for testing
+    const response = await container.containerFetch(mockRequest);
+
+    expect(startSpy).toHaveBeenCalledWith(8080, { abort: mockRequest.signal });
+    expect(response.status).toBe(429);
+    await expect(response.text()).resolves.toBe('you are requesting too many containers per second');
   });
 
   test('containerFetch should throw error when no port is specified', async () => {
@@ -302,13 +362,13 @@ describe('Container', () => {
 describe('getRandom', () => {
   test('should return a container stub', async () => {
     const mockBinding = {
-      idFromString: jest.fn().mockReturnValue('mock-id'),
+      idFromName: jest.fn().mockReturnValue('mock-id'),
       get: jest.fn().mockReturnValue({ mockStub: true }),
     };
 
     const result = await getRandom(mockBinding as any, 5);
 
-    expect(mockBinding.idFromString).toHaveBeenCalled();
+    expect(mockBinding.idFromName).toHaveBeenCalled();
     expect(mockBinding.get).toHaveBeenCalledWith('mock-id');
     expect(result).toEqual({ mockStub: true });
   });

--- a/src/tests/container.test.ts
+++ b/src/tests/container.test.ts
@@ -78,6 +78,7 @@ describe('Container', () => {
         },
       },
       blockConcurrencyWhile: jest.fn(fn => fn()),
+      abort: jest.fn(),
       container: {
         running: false,
         start: jest.fn(),
@@ -171,6 +172,29 @@ describe('Container', () => {
         cancellationOptions: { instanceGetTimeoutMS: 1, waitInterval: 1 },
       })
     ).rejects.toThrow('you are requesting too many containers per second');
+  });
+
+  test('startAndWaitForPorts should abort the durable object on final network loss', async () => {
+    mockCtx.container.monitor = jest.fn().mockReturnValue({
+      catch: jest
+        .fn()
+        .mockResolvedValue(
+          new Error('there is no container instance that can be provided to this durable object')
+        ),
+    });
+    mockCtx.container.getTcpPort = jest.fn().mockReturnValue({
+      fetch: jest.fn().mockRejectedValue(new Error('Network connection lost')),
+    });
+
+    await expect(
+      // @ts-ignore - ignore TypeScript errors for testing
+      container.startAndWaitForPorts({
+        ports: 8080,
+        cancellationOptions: { instanceGetTimeoutMS: 1, waitInterval: 1 },
+      })
+    ).rejects.toThrow('there is no container instance that can be provided to this durable object');
+
+    expect(mockCtx.abort).toHaveBeenCalled();
   });
 
   test('startAndWaitForPorts should start container without port checking if no ports available', async () => {


### PR DESCRIPTION
Keep the Cloudchamber backpressure error intact when container startup exhausts its retries so callers do not fall back to generic no-instance failures.

On the last retry there is no follow-up loop iteration to surface the monitor error. Preserve that runtime failure before falling back to the generic no-instance path.

Return HTTP 429 from containerFetch for the same startup error and cover the rate-limited paths with focused tests.