### PR TITLE
fix concurrent start race

### DIFF
--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1177,9 +1177,12 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
           return new Response(e instanceof Error ? e.message : String(e), { status: 429 });
         }
 
-        return new Response(`Failed to start container: ${e instanceof Error ? e.message : String(e)}`, {
-          status: 500,
-        });
+        return new Response(
+          `Failed to start container: ${e instanceof Error ? e.message : String(e)}`,
+          {
+            status: 500,
+          }
+        );
       }
     }
 
@@ -1340,6 +1343,15 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
   private onStopCalled = false;
   private state: ContainerState;
   private monitor: Promise<unknown> | undefined;
+
+  // Coalesces concurrent calls to startContainerIfNotRunning so we never
+  // call `this.container.start()` twice. Without this guard, two requests
+  // racing the readiness path can both pass the `if (this.container.running)`
+  // early-return (each yielding the DO input gate at storage awaits) and
+  // both reach the synchronous workerd `start()`, causing the second to
+  // throw "start() cannot be called on a container that is already running."
+  // See https://github.com/cloudflare/containers/issues/173.
+  private startInFlight: Promise<number> | undefined;
 
   private monitorSetup = false;
 
@@ -1688,7 +1700,9 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
     waitOptions: WaitOptions,
     options?: ContainerStartConfigOptions
   ): Promise<number> {
-    // Start the container if it's not running
+    // Fast path: container is already running. Safe to short-circuit
+    // synchronously since `this.container.running` only flips true after
+    // container.start() returns.
     if (this.container.running) {
       if (!this.monitor) {
         this.monitor = this.container.monitor();
@@ -1697,6 +1711,31 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
       return 0;
     }
 
+    // Coalesce concurrent starts. If another caller is already executing
+    // the start path, await their outcome (success or failure) instead of
+    // racing them to a second `this.container.start()` invocation.
+    if (this.startInFlight) {
+      return this.startInFlight;
+    }
+
+    const startPromise = this.doStartContainer(waitOptions, options);
+    this.startInFlight = startPromise;
+    try {
+      return await startPromise;
+    } finally {
+      // Clear the in-flight marker once this attempt resolves so future
+      // start attempts (e.g. after the container has stopped) can proceed.
+      // Use identity check in case a later attempt has already replaced it.
+      if (this.startInFlight === startPromise) {
+        this.startInFlight = undefined;
+      }
+    }
+  }
+
+  private async doStartContainer(
+    waitOptions: WaitOptions,
+    options?: ContainerStartConfigOptions
+  ): Promise<number> {
     const abortedSignal = new Promise(res => {
       waitOptions.signal?.addEventListener('abort', () => {
         res(true);

--- a/src/tests/container-race.test.ts
+++ b/src/tests/container-race.test.ts
@@ -1,0 +1,195 @@
+// Reproduction for https://github.com/cloudflare/containers/issues/173
+//
+// The error "start() cannot be called on a container that is already running."
+// is thrown by workerd's Container::start() at src/workerd/api/container.c++:209
+// via JSG_REQUIRE(!running, ...). It guards against the JS-visible `running`
+// flag being true.
+//
+// The race in @cloudflare/containers happens because the readiness path in
+// containerFetch -> startAndWaitForPorts -> startContainerIfNotRunning has
+// multiple `await` points BEFORE the synchronous `this.container.start(...)`
+// call. Each `await` yields the DO input gate, allowing two concurrent
+// fetches to both pass the `if (this.container.running) return 0;` early
+// exit. Whichever calls start() second hits the workerd JSG_REQUIRE.
+//
+// This test reproduces the race deterministically: it relies on the
+// natural microtask scheduling that `Promise.all([fetchA, fetchB])`
+// produces, with mocked storage that yields a microtask on every
+// operation (the same shape real DO storage has).
+
+jest.mock('partyserver');
+
+jest.mock(
+  'cloudflare:workers',
+  () => {
+    class MockDurableObject {
+      ctx: unknown;
+      env: unknown;
+      constructor(ctx: unknown, env: unknown) {
+        this.ctx = ctx;
+        this.env = env;
+      }
+    }
+    class MockWorkerEntrypoint {}
+    return {
+      DurableObject: MockDurableObject,
+      WorkerEntrypoint: MockWorkerEntrypoint,
+    };
+  },
+  { virtual: true }
+);
+
+jest.mock('node:async_hooks', () => {
+  return {
+    AsyncLocalStorage: class MockAsyncLocalStorage {
+      getStore() {
+        return null;
+      }
+      run(_store: any, fn: Function) {
+        return fn();
+      }
+    },
+  };
+});
+
+import { Container } from '../lib/container';
+
+/**
+ * Build a mock `ctx` that mimics workerd's behaviour for the race we care
+ * about:
+ *   - `ctx.container.running` starts false.
+ *   - `ctx.container.start()` is synchronous, sets `running = true`, and
+ *     throws with the workerd error string when called while already running.
+ *   - storage operations (get/put/setAlarm/sync) all return resolved
+ *     promises, mirroring real DO storage which always yields a microtask.
+ *   - blockConcurrencyWhile is identity (no real serialisation).
+ */
+function makeMockCtx() {
+  const containerState = {
+    running: false,
+  };
+
+  const start = jest.fn(() => {
+    if (containerState.running) {
+      // Mirrors workerd src/workerd/api/container.c++:209
+      throw new Error('start() cannot be called on a container that is already running.');
+    }
+    containerState.running = true;
+  });
+
+  // Jest's mockResolvedValue(undefined) gives a microtask boundary, which is
+  // the same yield-point real DO storage operations have.
+  // tcpPort.fetch is only reached on the success path; the race we want
+  // to demonstrate happens earlier, in start(). Returning a Response with
+  // explicit `webSocket: null` keeps the success path off the WebSocket
+  // branch in containerFetch.
+  const tcpPortFetch = jest.fn(
+    () =>
+      Promise.resolve({
+        status: 200,
+        webSocket: null,
+        body: null,
+        headers: new Headers(),
+      }) as unknown as Promise<Response>
+  );
+
+  const ctx: any = {
+    storage: {
+      get: jest.fn().mockResolvedValue(undefined),
+      put: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      setAlarm: jest.fn().mockResolvedValue(undefined),
+      sync: jest.fn().mockResolvedValue(undefined),
+      kv: {
+        get: jest.fn(),
+        put: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+      },
+      sql: { exec: jest.fn().mockReturnValue([]) },
+    },
+    blockConcurrencyWhile: jest.fn((fn: () => Promise<unknown>) => fn()),
+    abort: jest.fn(),
+    container: {
+      get running() {
+        return containerState.running;
+      },
+      set running(v: boolean) {
+        containerState.running = v;
+      },
+      start,
+      destroy: jest.fn(),
+      monitor: jest.fn().mockReturnValue(new Promise(() => {})),
+      getTcpPort: jest.fn(() => ({ fetch: tcpPortFetch })),
+    },
+  };
+
+  return { ctx, start, tcpPortFetch, containerState };
+}
+
+describe('Container concurrent-start race (issue #173)', () => {
+  test('two concurrent containerFetch calls do NOT both invoke start()', async () => {
+    const { ctx, start } = makeMockCtx();
+
+    // @ts-ignore - test-only construction
+    const container: Container = new Container(ctx, {});
+    (container as any).ctx = ctx;
+    container.defaultPort = 8080;
+
+    const reqA = new Request('https://example.com/a');
+    const reqB = new Request('https://example.com/b');
+
+    // Fire both concurrently. Both will:
+    //   1. await this.state.getState()  -> microtask yield
+    //   2. observe container.running === false
+    //   3. enter startContainerIfNotRunning
+    //   4. await this.state.setRunning()  -> microtask yield
+    //   5. await this.scheduleNextAlarm() -> microtask yield
+    //   6. call this.container.start(...) synchronously
+    //
+    // The second caller to reach step 6 sees running === true (set by the
+    // first caller) and the workerd guard throws.
+    const [resA, resB] = await Promise.all([
+      // @ts-ignore - protected method
+      container.containerFetch(reqA),
+      // @ts-ignore - protected method
+      container.containerFetch(reqB),
+    ]);
+
+    const startCallCount = start.mock.calls.length;
+    const bodies = await Promise.all(
+      [resA, resB].map(async r => {
+        try {
+          return typeof (r as Response).text === 'function' ? await (r as Response).text() : '';
+        } catch {
+          return '';
+        }
+      })
+    );
+
+    // Helpful diagnostic dump.
+    // eslint-disable-next-line no-console
+    console.log(
+      '[repro] start call count:',
+      startCallCount,
+      'statuses:',
+      resA.status,
+      resB.status,
+      'bodies:',
+      bodies
+    );
+
+    // PRIMARY ASSERTION: container.start() must only ever be invoked once
+    // when two requests race the readiness path. Today this fails (count: 2).
+    expect(startCallCount).toBe(1);
+
+    // SECONDARY ASSERTION: no response should surface the workerd
+    // "already running" error string. Today this also fails: one response
+    // is a 500 with body "Failed to start container: start() cannot be
+    // called on a container that is already running."
+    for (const body of bodies) {
+      expect(body).not.toContain(
+        'start() cannot be called on a container that is already running.'
+      );
+    }
+  });
+});


### PR DESCRIPTION
Problem: when two requests race the readiness path against a cold container, both can pass the `this.container.running` early-return because storage awaits yield the Durable Object input gate. The second caller then trips workerd's `JSG_REQUIRE` in `Container::start()` and the user sees a sporadic 500 even though the container is healthy, with no retry hint and no clean subclass workaround.

Solution: coalesce concurrent starts on a single in-flight promise so racing callers share one outcome.

Fixes #173