### PR TITLE
update linting rules and adjust code accordingly

### DIFF
--- a/.changeset/explicit-module-boundary-types.md
+++ b/.changeset/explicit-module-boundary-types.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/containers': patch
+---
+
+Add return types to exported functions and public methods to satisfy ESLint and improve type checking.

--- a/.changeset/preserve-caught-errors.md
+++ b/.changeset/preserve-caught-errors.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/containers': patch
+---
+
+Preserve original errors as `cause` when wrapping abort/timeout errors during container startup, making it easier to debug the underlying failure.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig(
     extends: [js.configs.recommended, tseslint.configs.recommended],
     rules: {
       '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'warn',
       '@typescript-eslint/no-unused-expressions': ['error', { allowTaggedTemplates: true }],
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,6 @@ export default defineConfig(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-unused-expressions': ['error', { allowTaggedTemplates: true }],
-      'preserve-caught-error': 'off',
     },
   },
   {

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1042,7 +1042,7 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
    *
    * Call this method whenever there is activity on the container
    */
-  public renewActivityTimeout() {
+  public renewActivityTimeout(): void {
     const timeoutInMs = parseTimeExpression(this.sleepAfter) * 1000;
     this.sleepAfterMs = Date.now() + timeoutInMs;
   }
@@ -1907,7 +1907,7 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
       });
   }
 
-  deleteSchedules(name: string) {
+  deleteSchedules(name: string): void {
     this.sql`DELETE FROM container_schedules WHERE callback = ${name}`;
   }
 

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -962,7 +962,7 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
           abortedSignal,
         ]);
         if (waitOptions.signal?.aborted) {
-          throw new Error('Container request aborted.');
+          throw new Error('Container request aborted.', { cause: e });
         }
       }
     }
@@ -1836,7 +1836,8 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
 
         if (waitOptions.signal?.aborted) {
           throw new Error(
-            'Aborted waiting for container to start as we received a cancellation signal'
+            'Aborted waiting for container to start as we received a cancellation signal',
+            { cause: error }
           );
         }
 
@@ -1854,7 +1855,7 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
 
           await handleError();
 
-          throw new Error(NO_CONTAINER_INSTANCE_ERROR);
+          throw new Error(NO_CONTAINER_INSTANCE_ERROR, { cause: error });
         }
 
         continue;

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -4,7 +4,7 @@
  * @param length - The length of the ID to generate (default: 9)
  * @returns A random string ID
  */
-export function generateId(length = 9) {
+export function generateId(length = 9): string {
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   const bytes = new Uint8Array(length);
   crypto.getRandomValues(bytes);

--- a/src/tests/fixtures.ts
+++ b/src/tests/fixtures.ts
@@ -14,7 +14,7 @@ export class MockWebSocket {
   send = vi.fn<(data: string | ArrayBuffer) => void>();
   close = vi.fn<(code?: number, reason?: string) => void>();
 
-  addEventListener(type: string, handler: EventHandler) {
+  addEventListener(type: string, handler: EventHandler): void {
     this.eventListeners[type].push(handler);
   }
 }
@@ -28,6 +28,7 @@ export const webSocketPairSpy = vi.fn(function WebSocketPair() {
 
 vi.stubGlobal('WebSocketPair', webSocketPairSpy);
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function makeMockCtx() {
   const ctx = {
     storage: {


### PR DESCRIPTION
Two linting rules were disabled that can now be re-enabled:

- `preserve-caught-error` - ensures we don't throw away useful information when throwing an exception
- `@typescript-eslint/explicit-module-boundary-types` - ensures public methods and exported functions declare return types (disabled for `makeMockCtx` since the returned mock is dynamically created)