### PR TITLE
Use the canonical `AlarmInvocationInfo` type

### DIFF
--- a/.changeset/alarm-invocation-info-type.md
+++ b/.changeset/alarm-invocation-info-type.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/containers': patch
+---
+
+Use the canonical `AlarmInvocationInfo` type from `@cloudflare/workers-types` for the `alarm()` parameter instead of an inline type. This is a no-op for users (the shape is identical), but keeps the override aligned with the Durable Object base class signature.

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1920,7 +1920,7 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
    * Executes any scheduled tasks that are due
    */
 
-  override async alarm(alarmProps?: { isRetry: boolean; retryCount: number }): Promise<void> {
+  override async alarm(alarmProps?: AlarmInvocationInfo): Promise<void> {
     if (
       alarmProps !== undefined &&
       alarmProps.isRetry &&


### PR DESCRIPTION
Use the canonical `AlarmInvocationInfo` type from `@cloudflare/workers-types` for the `alarm()` parameter instead of an inline type. This is a no-op for users (the shape is identical), but keeps the override aligned with the Durable Object base class signature.