### PR TITLE
Add non-waking container fetch method

### DIFF
--- a/.changeset/non-waking-container-forward.md
+++ b/.changeset/non-waking-container-forward.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/containers": patch
+---
+
+Add a non-starting `fetchIfRunning()` helper that only proxies requests to already-running, healthy containers without waking stopped containers.

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1141,6 +1141,24 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
   // ============
 
   /**
+   * Forward a request to the container only if it is already running and healthy.
+   *
+   * This method never starts the container or waits for ports to become ready.
+   */
+  public async fetchIfRunning(request: Request, port = this.defaultPort): Promise<Response> {
+    if (port === undefined) {
+      throw new Error('No port specified for container fetch');
+    }
+
+    const state = await this.state.getState();
+    if (!this.container.running || state.status !== 'healthy') {
+      return new Response('Container is not running', { status: 503 });
+    }
+
+    return await this.forwardToTcpPort(request, port);
+  }
+
+  /**
    * Send a request to the container (HTTP or WebSocket) using standard fetch API signature
    *
    * This method handles HTTP requests to the container.
@@ -1193,6 +1211,10 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
       }
     }
 
+    return await this.forwardToTcpPort(request, port);
+  }
+
+  private async forwardToTcpPort(request: Request, port: number): Promise<Response> {
     const tcpPort = this.container.getTcpPort(port);
 
     // Create URL for the container request

--- a/src/tests/container.test.ts
+++ b/src/tests/container.test.ts
@@ -154,6 +154,71 @@ describe('Container', () => {
     expect(tcpPort.fetch).toHaveBeenCalledWith(expect.any(String), expect.any(Object));
   });
 
+  for (const { name, running, status } of [
+    { name: 'stopped container', running: false, status: 'stopped' },
+    { name: 'running but non-healthy container', running: true, status: 'running' },
+  ] as const) {
+    test(`fetchIfRunning should not start or forward ${name}`, async ({ mockCtx, container }) => {
+      mockCtx.container.running = running;
+      mockCtx.storage.get.mockResolvedValue({ status, lastChange: Date.now() });
+
+      const response = await container.fetchIfRunning(
+        new Request('https://example.com/test'),
+        8080
+      );
+
+      expect(response.status).toBe(503);
+      expect(mockCtx.container.start).not.toHaveBeenCalled();
+      expect(mockCtx.container.getTcpPort).not.toHaveBeenCalled();
+    });
+  }
+
+  test('fetchIfRunning should use default port when port is omitted', async ({
+    mockCtx,
+    container,
+  }) => {
+    mockCtx.container.running = true;
+    mockCtx.storage.get.mockResolvedValue({ status: 'healthy', lastChange: Date.now() });
+
+    const response = await container.fetchIfRunning(new Request('https://example.com/test'));
+
+    expect(response.status).toBe(200);
+    expect(mockCtx.container.getTcpPort).toHaveBeenCalledWith(8080);
+  });
+
+  test('fetchIfRunning should bypass the startup path', async ({ mockCtx, container }) => {
+    using containerFetchSpy = vi.spyOn(container, 'containerFetch');
+    mockCtx.container.running = true;
+    mockCtx.storage.get.mockResolvedValue({ status: 'healthy', lastChange: Date.now() });
+
+    const response = await container.fetchIfRunning(new Request('https://example.com/test'), 8080);
+
+    expect(response.status).toBe(200);
+    expect(containerFetchSpy).not.toHaveBeenCalled();
+    expect(mockCtx.container.start).not.toHaveBeenCalled();
+    expect(mockCtx.container.getTcpPort).toHaveBeenCalledWith(8080);
+  });
+
+  test('fetchIfRunning should forward WebSocket requests', async ({ mockCtx, container }) => {
+    mockCtx.container.running = true;
+    mockCtx.storage.get.mockResolvedValue({ status: 'healthy', lastChange: Date.now() });
+
+    const response = await container.fetchIfRunning(
+      new Request('https://example.com/ws', {
+        headers: new Headers({
+          Upgrade: 'websocket',
+          Connection: 'Upgrade',
+        }),
+      }),
+      8080
+    );
+
+    const tcpPort = mockCtx.container.getTcpPort.mock.results[0].value;
+    expect(tcpPort.fetch).toHaveBeenCalled();
+    expect(webSocketPairSpy).toHaveBeenCalledOnce();
+    expect(response.status).toBe(200);
+  });
+
   test('containerFetch should return 429 when startup is rate limited', async ({ container }) => {
     const mockRequest = new Request('https://example.com/test', { method: 'GET' });
     using startSpy = vi


### PR DESCRIPTION
Some request paths need to proxy traffic only when a container is already available. The Sandbox SDK preview URL path is one example: stale preview URL requests should be rejected without waking or starting a stopped container. Other passive traffic, health-adjacent routing, or authorization-gated proxy paths have the same requirement.

Today the `Container` class exposes `fetch()` and `containerFetch()` for forwarding, but both start the container and wait for ports before proxying the request. That makes callers choose between accidentally waking containers or duplicating the base class's forwarding logic.

This adds `fetchIfRunning()` as a non-waking forwarding primitive. It forwards only when the container is already running and marked healthy, and otherwise returns without starting, probing, or waiting for ports. `containerFetch()` now shares the same internal forwarding helper after its existing start/wait behavior succeeds, so HTTP, WebSocket, activity timeout, and inflight request accounting stay consistent across both paths.