### PR TITLE
fix: match NOT_LISTENING_ERROR against local-dev runtime message

### DIFF
--- a/.changeset/fix-not-listening-error.md
+++ b/.changeset/fix-not-listening-error.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/containers": patch
+---
+
+Fix NOT_LISTENING_ERROR constant to match local-dev runtime error message

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -24,7 +24,7 @@ const NO_CONTAINER_INSTANCE_ERROR =
 const RATE_LIMITED_ERROR = 'you are requesting too many containers per second';
 const RUNTIME_SIGNALLED_ERROR = 'runtime signalled the container to exit:';
 const UNEXPECTED_EXIT_ERROR = 'container exited with unexpected exit code:';
-const NOT_LISTENING_ERROR = 'the container is not listening';
+const NOT_LISTENING_ERROR = 'container is not listening';
 const CONTAINER_STATE_KEY = '__CF_CONTAINER_STATE';
 const OUTBOUND_CONFIGURATION_KEY = 'OUTBOUND_CONFIGURATION';
 

--- a/src/tests/container.test.ts
+++ b/src/tests/container.test.ts
@@ -74,6 +74,31 @@ describe('Container', () => {
     expect(mockCtx.container.getTcpPort).toHaveBeenCalledWith(8080);
   });
 
+  test('startAndWaitForPorts should recognise local-dev "not listening" error without leading "the"', async ({
+    mockCtx,
+    container,
+  }) => {
+    // In local dev (wrangler dev) the runtime returns "container is not listening"
+    // without the leading "the" that production uses. Both variants must be
+    // recognised so doStartContainer treats the state as benign and returns
+    // instead of retrying until timeout.
+    const localDevError = new Error('container is not listening on TCP address 10.0.0.1:8080');
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(localDevError)
+      .mockResolvedValue(new Response('ok'));
+    mockCtx.container.getTcpPort.mockReturnValue({ fetch: fetchMock });
+
+    await container.startAndWaitForPorts(8080);
+
+    expect(mockCtx.container.getTcpPort).toHaveBeenCalledWith(8080);
+    // Exactly 2 calls: doStartContainer recognises the error and returns
+    // immediately (1 call), then waitForPort succeeds on its first attempt
+    // (1 call). Without the fix the error is not recognised, doStartContainer
+    // retries, and the count rises to 3+.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   test('startAndWaitForPorts should surface rate-limited startup errors on the final retry', async ({
     mockCtx,
     container,


### PR DESCRIPTION
## Problem

The `isNotListeningError` helper uses `.toLowerCase().includes(matchingString)` to detect the error. In production the runtime returns:

```
The container is not listening in the TCP address 10.0.0.1:8080
```

In local dev (`wrangler dev`) the runtime returns:

```
container is not listening on TCP address ...
```

The current constant `'the container is not listening'` is not a substring of the local-dev variant (which omits the leading "the"), so `isNotListeningError` never returns true. The readiness loop in `waitForPort` / `startAndWaitForPorts` retries indefinitely and the Durable Object blocks forever.

## Fix

Shorten the constant from `'the container is not listening'` to `'container is not listening'`. This is a substring of both variants, so the `.includes()` check works in both environments.

## Environment

```
macOS 26.5.1 (arm64, Apple Silicon)
Node:      v24.15.0
pnpm:      10.21.0
wrangler:  4.103.0
@cloudflare/containers: 0.3.7
Docker:    29.4.0 (via OrbStack 2.2.1, kernel 7.0.11-orbstack)
```

Not sure whether the Docker runtime (OrbStack vs Docker Desktop) matters for this particular issue. Mentioning it in case it is relevant.