### PR TITLE
fix: anchor the https scheme downgrade in containerFetch

### DIFF
--- a/.changeset/fix-container-fetch-scheme-downgrade.md
+++ b/.changeset/fix-container-fetch-scheme-downgrade.md
@@ -1,0 +1,8 @@
+---
+'@cloudflare/containers': patch
+---
+
+Fix `containerFetch` rewriting `https:` inside query strings and fragments. The scheme downgrade
+applied to container requests used an unanchored string replace, so a URL that was already
+`http:` had the first `https:` in its query or fragment downgraded instead of its scheme —
+corrupting parameters that carry an absolute URL, such as `/callback?redirect=https://app.example.com`.

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1204,8 +1204,13 @@ export class Container<Env = Cloudflare.Env> extends DurableObject<Env> {
 
     const tcpPort = this.container.getTcpPort(port);
 
-    // Create URL for the container request
-    const containerUrl = request.url.replace('https:', 'http:');
+    // Create URL for the container request. `tcpPort.fetch` opens a raw TCP connection to the
+    // container, which does not terminate TLS, so an https scheme has to be downgraded.
+    // The match is anchored on purpose: an unanchored string replace rewrites the first `https:`
+    // anywhere in the URL, which corrupts query strings and fragments that carry an absolute URL
+    // (for example `/callback?redirect=https://app.example.com`) whenever the scheme is already
+    // http.
+    const containerUrl = request.url.replace(/^https:/, 'http:');
 
     this.inflightRequests++;
 

--- a/src/tests/container.test.ts
+++ b/src/tests/container.test.ts
@@ -360,6 +360,42 @@ describe('Container', () => {
     expect(tcpPort.fetch).toHaveBeenCalledWith('http://example.com/admin', expect.any(Request));
   });
 
+  test('containerFetch should preserve https: in query strings and fragments', async ({
+    mockCtx,
+    container,
+  }) => {
+    mockCtx.container.running = true;
+    mockCtx.storage.get.mockResolvedValue({ status: 'healthy', lastChange: Date.now() });
+
+    await container.containerFetch('/callback?redirect=https://app.example.com#https://fragment');
+
+    const tcpPort = mockCtx.container.getTcpPort.mock.results[0].value;
+    expect(tcpPort.fetch).toHaveBeenCalledWith(
+      'http://container/callback?redirect=https://app.example.com#https://fragment',
+      expect.any(Request)
+    );
+  });
+
+  test('containerFetch should downgrade only the scheme of an https URL', async ({
+    mockCtx,
+    container,
+  }) => {
+    mockCtx.container.running = true;
+    mockCtx.storage.get.mockResolvedValue({ status: 'healthy', lastChange: Date.now() });
+
+    await container.containerFetch(
+      'https://example.com/callback?redirect=https://app.example.com',
+      { method: 'GET' },
+      3000
+    );
+
+    const tcpPort = mockCtx.container.getTcpPort.mock.results[0].value;
+    expect(tcpPort.fetch).toHaveBeenCalledWith(
+      'http://example.com/callback?redirect=https://app.example.com',
+      expect.any(Request)
+    );
+  });
+
   test('containerFetch should return 429 when startup is rate limited', async ({ container }) => {
     const mockRequest = new Request('https://example.com/test', { method: 'GET' });
     using startSpy = vi


### PR DESCRIPTION
## Summary

- anchor the scheme rewrite so it only matches the URL's scheme
- add regression coverage for `https:` in query strings and fragments
- pin the intended scheme downgrade so it can't be dropped by a future fix
- publish as a patch release

## Why

`containerFetch` downgrades https to http before forwarding, because `tcpPort.fetch` opens a raw TCP connection to the container and nothing terminates TLS. That rewrite used an unanchored string replace:

```ts
const containerUrl = request.url.replace('https:', 'http:');
```

`String.prototype.replace` with a string pattern replaces only the first occurrence, and the match isn't anchored to the start. When the URL's scheme is already `http:`, the first `https:` in the string is somewhere in the path, query, or fragment — and that gets rewritten instead of the scheme.

So this:

```ts
await this.containerFetch('/callback?redirect=https://app.example.com');
```

arrives at the container as:

```
http://container/callback?redirect=http://app.example.com
                                        ^ silently downgraded
```

Any endpoint taking an unencoded absolute URL as a parameter is affected — OAuth `redirect_uri`, webhook callbacks, proxy targets, SSO `RelayState`. Percent-encoded values (`https%3A%2F%2F…`) are unaffected, since they don't contain the literal `https:`.

Absolute `https://` URLs were never affected: the first match is the scheme, so the replacement did the right thing and the rest of the URL survived.

## Relationship to #238

The bug is pre-existing, but #238 widened its reach considerably. Relative paths now resolve against `http://container`, which means every relative-path call has an `http:` scheme — precisely the condition that triggers this. Before #238, relative paths threw outright, so the corruption was largely unreachable.

## Approach

Anchoring the regex is the whole fix. I also considered operating on the parsed URL:

```ts
const target = new URL(request.url);
if (target.protocol === 'https:') target.protocol = 'http:';
```

`new URL(request.url).href` round-trips `request.url` exactly (verified across default ports, empty paths, and percent-encoded characters), so the two are equivalent. The anchored regex wins on being a one-token change with no normalization risk and no extra allocation in the request-proxy hot path.

The comment above the line explains why the anchor matters, since the obvious "simplification" back to a string argument reintroduces the bug silently.

## Tests

Two cases in `src/tests/container.test.ts`:

- **preserves `https:` in query strings and fragments** — the regression. Fails on `main`, passes here.
- **downgrades only the scheme of an https URL** — asserts the intended downgrade still happens and doesn't touch a `https:` query param on the same URL. This case was already correct; it's pinned so an over-eager future fix can't disable the downgrade entirely.

Only the first fails without the change, which is expected — the second documents behavior that already worked.
